### PR TITLE
Fix old spec processing

### DIFF
--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -26,7 +26,7 @@ jobs:
         run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.1.3
 
       - name: Run generation
-        run: time kiota generate -l csharp --ll trace -o generated/csharp/Octokit -n Octokit -d schemas/updated/api.github.com.json --co
+        run: time kiota generate -l csharp --ll trace -o generated/csharp/Octokit -n Octokit -d schemas/updated/api.github.com.json
 
       - name: Build post-processing
         run: go build -o post-processors/csharp/post-processor post-processors/csharp/main.go

--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -20,10 +20,10 @@ jobs:
 
       - uses: actions/setup-go@v3.5.0
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.4'
 
       - name: Install kiota
-        run: dotnet tool install --global --prerelease Microsoft.OpenApi.Kiota
+        run: dotnet tool install --global --prerelease Microsoft.OpenApi.Kiota --version 1.1.3
 
       - name: Run generation
         run: time kiota generate -l csharp --ll trace -o generated/csharp/Octokit -n Octokit -d schemas/updated/api.github.com.json --co

--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: '1.20.4'
 
       - name: Install kiota
-        run: dotnet tool install --global --prerelease Microsoft.OpenApi.Kiota --version 1.1.3
+        run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.1.3
 
       - name: Run generation
         run: time kiota generate -l csharp --ll trace -o generated/csharp/Octokit -n Octokit -d schemas/updated/api.github.com.json --co

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: '1.20.4'
 
       - name: Install kiota
-        run: dotnet tool install --global --prerelease Microsoft.OpenApi.Kiota --version 1.1.3
+        run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.1.3
 
       - name: Run generation
         run: time kiota generate -l go --ll trace -o generated/go -n kiota -d schemas/updated/api.github.com.json --co

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -20,10 +20,10 @@ jobs:
 
       - uses: actions/setup-go@v3.5.0
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.4'
 
       - name: Install kiota
-        run: dotnet tool install --global --prerelease Microsoft.OpenApi.Kiota
+        run: dotnet tool install --global --prerelease Microsoft.OpenApi.Kiota --version 1.1.3
 
       - name: Run generation
         run: time kiota generate -l go --ll trace -o generated/go -n kiota -d schemas/updated/api.github.com.json --co

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ generated/csharp/Octokit
 generated/csharp/kiota-lock.json
 generated/csharp/bin
 generated/csharp/obj
+generated/csharp/Kiota
 post-processors/csharp/post-processor
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is a prototype of code generation from GitHub's OpenAPI specific
 - Install
 	- [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
 	- [Latest version of Go](https://go.dev/dl/)
-	- Kiota: `dotnet tool install --global --prerelease Microsoft.OpenApi.Kiota`
+	- Kiota: `dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.1.3`
 - Validation of SDKs in other platforms such as Ruby require that platform to be installed as well
 
 ## Usage

--- a/generated/csharp/.vscode/launch.json
+++ b/generated/csharp/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			// Use IntelliSense to find out which attributes exist for C# debugging
+			// Use hover for the description of the existing attributes
+			// For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+			"name": ".NET Core Launch (console)",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			// If you have changed target frameworks, make sure to update the program path.
+			"program": "${workspaceFolder}/bin/Debug/net7.0/csharp.dll",
+			"args": [],
+			"cwd": "${workspaceFolder}",
+			// For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+			"console": "internalConsole",
+			"stopAtEntry": false
+		},
+		{
+			"name": ".NET Core Attach",
+			"type": "coreclr",
+			"request": "attach"
+		}
+	]
+}

--- a/generated/csharp/.vscode/tasks.json
+++ b/generated/csharp/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "build",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"build",
+				"${workspaceFolder}/csharp.csproj",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "publish",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"publish",
+				"${workspaceFolder}/csharp.csproj",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "watch",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"watch",
+				"run",
+				"--project",
+				"${workspaceFolder}/csharp.csproj"
+			],
+			"problemMatcher": "$msCompile"
+		}
+	]
+}

--- a/generated/csharp/Program.cs
+++ b/generated/csharp/Program.cs
@@ -3,34 +3,54 @@ using Azure.Core;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Authentication.Azure;
 using Microsoft.Kiota.Http.HttpClientLibrary;
+using Kiota;
 
-var GHPAT = "TODO";
+var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+if (string.IsNullOrEmpty(token))
+{
+	Console.WriteLine("GITHUB_TOKEN environment variable is not set");
+	//   throw new Exception("GITHUB_TOKEN environment variable is not set");
+}
 
-var authProvider = new AnonymousAuthenticationProvider();
-var requestAdapter = new HttpClientRequestAdapter(authProvider);
+var authProvider = new ApiKeyAuthenticationProvider(token, "Authorization", ApiKeyAuthenticationProvider.KeyLocation.Header, new string[] { "https://api.github.com" });
+var requestAdapter = new HttpClientRequestAdapter(authProvider, null, null, new HttpClient
+{
+	BaseAddress = new Uri("https://api.github.com/")
+});
+var pathParameters = new Dictionary<string, object>() {
+		{"baseurl", "https://api.github.com/"},
+	};
+var octocatPathParams = new Kiota.Octocat.OctocatRequestBuilder(pathParameters, requestAdapter);
+Action<Kiota.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration> requestConfig =
+	delegate (Kiota.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration config)
+	{
+		config.QueryParameters.S = "Hey yo!";
+		config.Headers.Add("Accept", "application/vnd.github.v3+json");
+	};
 
+try
+{
+	Stream requestPathParam = await octocatPathParams.GetAsync(requestConfig);
+	StreamReader rPathParams = new StreamReader(requestPathParam);
+	string responsePathParams = rPathParams.ReadToEnd();
+	Console.WriteLine(responsePathParams);
+}
+catch (Exception ex)
+{
+	Console.WriteLine(ex.Message);
+	throw;
+}
 
-// Passing path parms
-
-// var pathParameters =new Dictionary<string, object>() {
-//   {"s", "Hey yo!"}
-// };
-// var octocatPathParms = new ApiSdk.Octocat.OctocatRequestBuilder(pathParameters, requestAdapter);
-// Stream requestPathParm = await octocatPathParms.GetAsync();
-
-// StreamReader rPathParms = new StreamReader(requestPathParm);
-// string responsePathParms = rPathParms.ReadToEnd();
-// Console.WriteLine(responsePathParms);
 
 // Passing path parms
 
 // Basic request
 
-var client = new Octokit.ApiClient(requestAdapter);
-var request = await client.Octocat.GetAsync();
+// var client = new Octokit.ApiClient(requestAdapter);
+// var request = await client.Octocat.GetAsync();
 
-StreamReader reader = new StreamReader(request);
-string response = reader.ReadToEnd();
-Console.WriteLine(response);
+// StreamReader reader = new StreamReader(request);
+// string response = reader.ReadToEnd();
+// Console.WriteLine(response);
 
 // Basic request

--- a/generated/csharp/Program.cs
+++ b/generated/csharp/Program.cs
@@ -3,7 +3,7 @@ using Azure.Core;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Authentication.Azure;
 using Microsoft.Kiota.Http.HttpClientLibrary;
-using Kiota;
+using Octokit;
 
 var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
 if (string.IsNullOrEmpty(token))
@@ -20,9 +20,9 @@ var requestAdapter = new HttpClientRequestAdapter(authProvider, null, null, new 
 var pathParameters = new Dictionary<string, object>() {
 		{"baseurl", "https://api.github.com/"},
 	};
-var octocatPathParams = new Kiota.Octocat.OctocatRequestBuilder(pathParameters, requestAdapter);
-Action<Kiota.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration> requestConfig =
-	delegate (Kiota.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration config)
+var octocatPathParams = new Octokit.Octocat.OctocatRequestBuilder(pathParameters, requestAdapter);
+Action<Octokit.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration> requestConfig =
+	delegate (Octokit.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration config)
 	{
 		config.QueryParameters.S = "Hey yo!";
 		config.Headers.Add("Accept", "application/vnd.github.v3+json");

--- a/generated/csharp/csharp.csproj
+++ b/generated/csharp/csharp.csproj
@@ -10,12 +10,12 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.28.0" />
     <PackageReference Include="Azure.Identity" Version="1.8.2" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.5" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/post-processors/go/main.go
+++ b/post-processors/go/main.go
@@ -416,5 +416,27 @@ type ItemStarredRepositoryable interface {
 		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
 	}
 
+	toReplace = `res, err := m.BaseRequestBuilder.RequestAdapter.SendCollection(ctx, requestInfo, i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.CreateDateOnlyFromDiscriminatorValue, errorMapping)`
+	replaceWith = `res, err := m.BaseRequestBuilder.RequestAdapter.SendCollection(ctx, requestInfo, i158396662f32fe591e8faa247af18558546841dba91f24f5c824e11e34188830.CreateKeySimpleFromDiscriminatorValue, errorMapping)`
+
+	if strings.Contains(inputFile, toReplace) {
+		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
+	}
+
+	// remove unused imports that are present in specific files for some reason
+	if strings.Contains(filename, "issue_event_for_issue.go") || strings.Contains(filename, "timeline_issue_events.go") {
+		toReplace = `import (
+    i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f "github.com/microsoft/kiota-abstractions-go"
+    i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91 "github.com/microsoft/kiota-abstractions-go/serialization"
+)`
+
+		replaceWith = `import (
+    i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91 "github.com/microsoft/kiota-abstractions-go/serialization"
+)`
+		if strings.Contains(inputFile, toReplace) {
+			inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
+		}
+	}
+
 	return inputFile
 }

--- a/post-processors/go/main.go
+++ b/post-processors/go/main.go
@@ -63,12 +63,12 @@ func run() error {
 	log.Printf("output of module initialization: %v", output)
 
 	deps := [6]string{
-		"github.com/microsoft/kiota-abstractions-go@v0.17.0",
-		"github.com/microsoft/kiota-http-go@v0.14.0",
-		"github.com/microsoft/kiota-serialization-form-go@v0.3.0",
-		"github.com/microsoft/kiota-serialization-json-go@v0.8.0",
+		"github.com/microsoft/kiota-abstractions-go@v0.20.0",
+		"github.com/microsoft/kiota-http-go@v0.17.0",
+		"github.com/microsoft/kiota-serialization-form-go@v0.9.1",
+		"github.com/microsoft/kiota-serialization-json-go@v0.9.3",
 		"github.com/microsoft/kiota-authentication-azure-go@v0.6.0",
-		"github.com/microsoft/kiota-serialization-text-go@v0.7.0",
+		"github.com/microsoft/kiota-serialization-text-go@v0.7.1",
 	}
 
 	// run go get on deps


### PR DESCRIPTION
When working on #10, I came across build errors due to Kiota releasing their v1.0 major version. This PR:
- pins to a specific Kiota version (instead of installing the latest each time)
- bumps Kiota's Go dependency versions
- adds additional hacks to get Go compilation working again with the old hand-edited spec
- fixes the .NET generation and build process to work with the new major version of Kiota

Re: these hacks, at some point in the near future of generative SDK work they will need to be codified and solved for real, whether that's simply filtering out the broken endpoints, working with Kiota upstream, or discovering as-yet-hidden spec errors. However, I believe that's a task for another day given our current focus on the OpenAPI spec and linting. 

Note that running the sample .NET application results in an error. I'm considering this out of scope for now as we don't have an automatically added sample Go application yet either. 