### PR TITLE
Clean up sample applications

### DIFF
--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.20.4'
 
       - name: Install kiota
-        run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.1.3
+        run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.2.0
 
       - name: Download latest schema
         run: go run schemas/main.go --schema-next=false

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -32,7 +32,7 @@ jobs:
         run: go run schemas/main.go --schema-next=false
 
       - name: Run generation
-        run: time kiota generate -l go --ll trace -o generated/go -n kiota -d schemas/downloaded.json --co
+        run: time kiota generate -l go --ll trace -o generated/go -n kiota -d schemas/downloaded.json
 
       - name: Build post-processing
         run: go build -o post-processors/go/post-processor post-processors/go/main.go

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.20.4'
 
       - name: Install kiota
-        run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.1.3
+        run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.2.0
 
       - name: Download latest schema
         run: go run schemas/main.go --schema-next=false

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ output.txt
 schemas/downloaded.json
 
 # GO Related
-generated/go
+generated/go/*
+!generated/go/main.go
 post-processors/go/output
 post-processors/go/post-processor
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is a prototype of code generation from GitHub's OpenAPI specific
 - Install
 	- [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
 	- [Latest version of Go](https://go.dev/dl/)
-	- Kiota: `dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.1.3`
+	- Kiota: `dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.2.0`
 - Validation of SDKs in other platforms such as Ruby require that platform to be installed as well
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -15,20 +15,22 @@ This repository is a prototype of code generation from GitHub's OpenAPI specific
 ### Go
 
 1. Download the latest schema: `go run schemas/main.go --schema-next=false`
-1. Run generation: `kiota generate -l go --ll trace -o generated/go -n kiota -d schemas/downloaded.json --co > output.txt 2>&1`
+1. Run generation: `kiota generate -l go --ll trace -o generated/go -n kiota -d schemas/downloaded.json > output.txt 2>&1`
 	1. Alternately, you may debug using the VSCode launch.json in the microsoft/kiota repo.
 1. Run `go build -o post-processors/go/post-processor post-processors/go/main.go` to build the post-processor.
 1. Run `post-processors/go/post-processor $(pwd)/generated/go` to execute the post-processor.
 1. Run `go build ./...` from the directory in which you've output the generated code to check compilation.
+1. Run `go run main.go` from the directory in which you've output the generated code in order to run the sample application.
 1. For more info, [see Kiota documentation](https://microsoft.github.io/kiota/get-started/go.html).
 <!-- TODO(kfcampbell): create main.go file and run it -->
 
 ### C#
 
 1. Download the latest schema: `go run schemas/main.go --schema-next=false`
-1. Run generation: `kiota generate -l csharp --ll trace -o generated/csharp -n kiota -d schemas/downloaded.json --co > output.txt 2>&1`
+1. Run generation: `kiota generate -l csharp --ll trace -o generated/csharp -n kiota -d schemas/downloaded.json > output.txt 2>&1`
 	1. Alternately, you may debug using the VSCode launch.json in the microsoft/kiota repo.
 1. Run `go build -o post-processors/csharp/post-processor post-processors/csharp/main.go` to build the post-processor.
 1. Run `post-processors/csharp/post-processor $(pwd)/generated/csharp` to execute the post-processor.
 1. Run `dotnet build` from the directory in which you've output the generated code to check compilation.
+1. Run `dotnet run` from the directory in which you've output the generated code in order to run the sample application.
 1. For more info, [see Kiota documentation](https://microsoft.github.io/kiota/get-started/dotnet.html).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository is a prototype of code generation from GitHub's OpenAPI specific
 ### C#
 
 1. Download the latest schema: `go run schemas/main.go --schema-next=false`
-1. Run generation: `kiota generate -l csharp --ll trace -o generated/csharp -n kiota -d schemas/downloaded.json > output.txt 2>&1`
+1. Run generation: `kiota generate -l csharp --ll trace -o generated/csharp -n Octokit -d schemas/downloaded.json > output.txt 2>&1`
 	1. Alternately, you may debug using the VSCode launch.json in the microsoft/kiota repo.
 1. Run `go build -o post-processors/csharp/post-processor post-processors/csharp/main.go` to build the post-processor.
 1. Run `post-processors/csharp/post-processor $(pwd)/generated/csharp` to execute the post-processor.

--- a/generated/csharp/Program.cs
+++ b/generated/csharp/Program.cs
@@ -3,7 +3,7 @@ using Azure.Core;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Authentication.Azure;
 using Microsoft.Kiota.Http.HttpClientLibrary;
-using Octokit;
+using Kiota;
 
 var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
 if (string.IsNullOrEmpty(token))
@@ -20,9 +20,9 @@ var requestAdapter = new HttpClientRequestAdapter(authProvider, null, null, new 
 var pathParameters = new Dictionary<string, object>() {
 		{"baseurl", "https://api.github.com/"},
 	};
-var octocatPathParams = new Octokit.Octocat.OctocatRequestBuilder(pathParameters, requestAdapter);
-Action<Octokit.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration> requestConfig =
-	delegate (Octokit.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration config)
+var octocatPathParams = new Kiota.Octocat.OctocatRequestBuilder(pathParameters, requestAdapter);
+Action<Kiota.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration> requestConfig =
+	delegate (Kiota.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration config)
 	{
 		config.QueryParameters.S = "Hey yo!";
 		config.Headers.Add("Accept", "application/vnd.github.v3+json");

--- a/generated/csharp/Program.cs
+++ b/generated/csharp/Program.cs
@@ -3,7 +3,7 @@ using Azure.Core;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Authentication.Azure;
 using Microsoft.Kiota.Http.HttpClientLibrary;
-using Kiota;
+using Octokit;
 
 var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
 if (string.IsNullOrEmpty(token))
@@ -20,9 +20,9 @@ var requestAdapter = new HttpClientRequestAdapter(authProvider, null, null, new 
 var pathParameters = new Dictionary<string, object>() {
 		{"baseurl", "https://api.github.com/"},
 	};
-var octocatPathParams = new Kiota.Octocat.OctocatRequestBuilder(pathParameters, requestAdapter);
-Action<Kiota.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration> requestConfig =
-	delegate (Kiota.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration config)
+var octocatPathParams = new Octokit.Octocat.OctocatRequestBuilder(pathParameters, requestAdapter);
+Action<Octokit.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration> requestConfig =
+	delegate (Octokit.Octocat.OctocatRequestBuilder.OctocatRequestBuilderGetRequestConfiguration config)
 	{
 		config.QueryParameters.S = "Hey yo!";
 		config.Headers.Add("Accept", "application/vnd.github.v3+json");

--- a/generated/go/main.go
+++ b/generated/go/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	auth "github.com/microsoft/kiota-abstractions-go/authentication"
+	http "github.com/microsoft/kiota-http-go"
+)
+
+func main() {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		log.Fatalf("GITHUB_TOKEN must be provided")
+	}
+
+	tokenProvider, err := auth.NewApiKeyAuthenticationProvider(token, "authorization", auth.HEADER_KEYLOCATION)
+	if err != nil {
+		log.Fatalf("failed to initialize token provider: %v", err)
+	}
+
+	adapter, err := http.NewNetHttpRequestAdapter(tokenProvider)
+	if err != nil {
+		log.Fatalf("Error creating request adapter: %v", err)
+	}
+
+	client := NewApiClient(adapter)
+
+	cat, err := client.Octocat().Get(context.Background(), nil)
+	if err != nil {
+		log.Fatalf("error getting octocat: %v", err)
+	}
+	fmt.Printf("%v\n", string(cat))
+
+	// uncomment to make authenticated request for private user emails
+	// x, err := client.User().Emails().Get(context.Background(), nil)
+	// if err != nil {
+	// 	log.Fatalf("%v\n", err)
+	// }
+
+	// for _, v := range x {
+	// 	fmt.Printf("%v\n", *v.GetEmail())
+	// }
+}

--- a/post-processors/go/main.go
+++ b/post-processors/go/main.go
@@ -64,12 +64,12 @@ func run() error {
 	log.Printf("output of module initialization: %v", output)
 
 	deps := [6]string{
-		"github.com/microsoft/kiota-abstractions-go@v0.20.0",
-		"github.com/microsoft/kiota-http-go@v0.17.0",
-		"github.com/microsoft/kiota-serialization-form-go@v0.9.1",
-		"github.com/microsoft/kiota-serialization-json-go@v0.9.3",
-		"github.com/microsoft/kiota-authentication-azure-go@v0.6.0",
-		"github.com/microsoft/kiota-serialization-text-go@v0.7.1",
+		"github.com/microsoft/kiota-abstractions-go@v1.0.0",
+		"github.com/microsoft/kiota-http-go@v1.0.0",
+		"github.com/microsoft/kiota-serialization-form-go@v1.0.0",
+		"github.com/microsoft/kiota-serialization-json-go@v1.0.0",
+		"github.com/microsoft/kiota-authentication-azure-go@v1.0.0",
+		"github.com/microsoft/kiota-serialization-text-go@v1.0.0",
 	}
 
 	// run go get on deps

--- a/post-processors/go/main.go
+++ b/post-processors/go/main.go
@@ -45,6 +45,7 @@ func run() error {
 		fileContents = fixMissingErrorReferences(fileContents)
 		fileContents = dirtyHackToBreakFunctionalityForCompilation(fileContents, file.Name())
 		fileContents = removeUnusedImports(fileContents, file.Name())
+		fileContents = fixPackageNameInAPIClient(fileContents, file.Name())
 
 		// TODO(kfcampbell): verify file permission is what we want
 		err = os.WriteFile(path, []byte(fileContents), 0666)
@@ -439,6 +440,18 @@ func removeUnusedImports(inputFile string, filename string) string {
 		replaceWith := `import (
     i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91 "github.com/microsoft/kiota-abstractions-go/serialization"
 )`
+		if strings.Contains(inputFile, toReplace) {
+			inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
+		}
+	}
+	return inputFile
+}
+
+func fixPackageNameInAPIClient(inputFile string, filename string) string {
+	if strings.Contains(filename, "api_client.go") {
+		toReplace := `package kiota`
+		replaceWith := `package main`
+
 		if strings.Contains(inputFile, toReplace) {
 			inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
 		}


### PR DESCRIPTION
Our sample app in Go was non-existent and in C# it was non-building. This PR fixes both of those issues. 

The Go sample app has a commented-out section I've manually tested works to retrieve private user profile information when appropriate auth creds are provided. 