### PR TITLE
Call the scripts instead of sourcing them

### DIFF
--- a/scripts/generate-csharp.sh
+++ b/scripts/generate-csharp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source ./scripts/install-tools.sh
+./scripts/install-tools.sh
 
 go run schemas/main.go --schema-next=false
 

--- a/scripts/generate-go.sh
+++ b/scripts/generate-go.sh
@@ -7,7 +7,7 @@
 # rm -rf generated/go/
 # git restore generated/
 
-source ./scripts/install-tools.sh
+./scripts/install-tools.sh
 
 set -ex
 


### PR DESCRIPTION
Sourcing the scripts will load functionality from them but not execute it. This small update causes the `install-tools.sh` script's code to be executed. Another way to do this would be to refactor the script to export a function and then call that function in each parent script; I've elected to go this way because it's fewer lines but I'm happy to change that as desired. 

On this branch:
```
 sh$ ./scripts/generate-go.sh
The correct version (1.8.1) of microsoft.openapi.kiota is installed...skipping install step
+ go run schemas/main.go --schema-next=false
2023/11/07 11:00:00 Downloading latest schema from descriptions directory
```

On main:
```
 sh$ ./scripts/generate-go.sh
./scripts/generate-go.sh: 10: source: not found
+ go run schemas/main.go --schema-next=false
```

I'm not sure why my environment is unable to recognize `source`. 