### PR TITLE
Use kiota list command to install dependencies

### DIFF
--- a/post-processors/go/main.go
+++ b/post-processors/go/main.go
@@ -82,7 +82,6 @@ func run() error {
 	if err != nil {
 		fmt.Printf("could not run kiota info: %v\nfull error log:\n%s", err, stderr.String())
 	}
-	fmt.Printf("kiota info output:\n%s\n", string(output))
 
 	// parse the json returned by kiota info, extract the "dependencies" field,
 	// and construct a "go get" command for each with the "name" and "version" subfields used.


### PR DESCRIPTION
Fixes #17. 

Instead of hard-coding dependencies and their versions, this PR uses the `kiota list` command to get them. 

:warning: **Note:** :warning: in a very "production" application, this should use structs rather than interface{}s and it should be unit-tested, which it's not currently. @nickfloyd do you think we're at an appropriate stage where I should sharpen it like so? Is this just me being lazy? Are we in enough flux that I shouldn't do so yet and instead file an issue to tackle it after the alpha release? 