### PR TITLE
Bump Kiota to v1.8.2

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.21.4'
 
       - name: Install kiota
-        run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.8.1
+        run: dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.8.2
 
       - name: Clone the existing go-sdk
         run: |

--- a/post-processors/go/main.go
+++ b/post-processors/go/main.go
@@ -43,7 +43,6 @@ func run() error {
 
 		fileContents = fixImports(fileContents)
 		fileContents = fixCreateDateOnlyFromDiscriminatorValue(fileContents, file.Name())
-		fileContents = removeModelsKiotaDoesNotCleanUp(fileContents)
 		fileContents = dirtyHackForVersionsRequestBuilder(fileContents, file.Name())
 		fileContents = fixKiotaNonDeterminism(fileContents, file.Name())
 
@@ -187,25 +186,6 @@ func dirtyHackForVersionsRequestBuilder(inputFile string, fileName string) strin
     //     if v != nil {
     //         val[i] = *(v.(*i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.DateOnly))
     //     }`
-
-	if strings.Contains(inputFile, toReplace) {
-		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
-	}
-
-	return inputFile
-}
-
-func removeModelsKiotaDoesNotCleanUp(inputFile string) string {
-	toReplace := `// If specified, only code scanning alerts with this severity will be returned.
-    SeverityAsCodeScanningAlertSeverity *i158396662f32fe591e8faa247af18558546841dba91f24f5c824e11e34188830.CodeScanningAlertSeverity ` + "`uriparametername:\"severity\"`"
-	replaceWith := ``
-
-	if strings.Contains(inputFile, toReplace) {
-		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
-	}
-
-	toReplace = `// If specified, only code scanning alerts with this state will be returned.
-    StateAsCodeScanningAlertStateQuery *i158396662f32fe591e8faa247af18558546841dba91f24f5c824e11e34188830.CodeScanningAlertStateQuery ` + "`uriparametername:\"state\"`"
 
 	if strings.Contains(inputFile, toReplace) {
 		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -4,7 +4,7 @@
 KIOTA_TOOL_NAME="microsoft.openapi.kiota"
 # This version can only increase, never decrease. If you want to use a lower version, you need to uninstall the tool first.
 # dotnet tool uninstall Microsoft.OpenApi.Kiota --global
-KIOTA_TOOL_VERSION="1.8.1" 
+KIOTA_TOOL_VERSION="1.8.2"
 
 # Check if the tool is installed globally
 if dotnet tool list -g | grep -q $KIOTA_TOOL_NAME; then


### PR DESCRIPTION
Fixes #22 (thanks @baywet!) https://github.com/microsoft/kiota/issues/3637 has been fixed and so we can bump our Kiota version and remove a post-processor workaround. 