### PR TITLE
Adds a basic media type handler

### DIFF
--- a/generated/csharp/GitHub/Client/OctokitClientFactory.cs
+++ b/generated/csharp/GitHub/Client/OctokitClientFactory.cs
@@ -31,6 +31,7 @@ public static class OctokitClientFactory
         {
             new APIVersionHandler(),
             new UserAgentHandler(),
+            new MediaTypeHandler(),
         };
     }
 

--- a/generated/csharp/GitHub/Middleware/APIVersionHandler.cs
+++ b/generated/csharp/GitHub/Middleware/APIVersionHandler.cs
@@ -25,7 +25,9 @@ class APIVersionHandler : DelegatingHandler
 
     var apiVersionHandlerOption = request.GetRequestOption<APIVersionOptions>() ?? _apiVersionOptions;
 
-    if (!request.Headers.Contains(ApiVersionHeaderKey) || !request.Headers.GetValues(ApiVersionHeaderKey).Any(x => apiVersionHandlerOption.APIVersion.Equals(x, StringComparison.OrdinalIgnoreCase)))
+    if (!request.Headers.Contains(ApiVersionHeaderKey) 
+    || !request.Headers.GetValues(ApiVersionHeaderKey)
+      .Any(x => apiVersionHandlerOption.APIVersion.Equals(x, StringComparison.OrdinalIgnoreCase)))
     {
       request.Headers.Add(ApiVersionHeaderKey, apiVersionHandlerOption.APIVersion);
     }

--- a/generated/csharp/GitHub/Middleware/MediaTypeHandler.cs
+++ b/generated/csharp/GitHub/Middleware/MediaTypeHandler.cs
@@ -1,0 +1,36 @@
+using GitHub.Octokit.Client.Middleware.Options;
+using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
+
+namespace GitHub.Octokit.Client.Middleware;
+
+/// <summary>
+/// Represents a handler that adds the API version header to outgoing HTTP requests.
+/// </summary>
+class MediaTypeHandler : DelegatingHandler
+{
+  private const string MediaTypeHeaderKey = "Accept";
+
+  private readonly MediaTypeOptions _mediaTypeOptions;
+
+  public MediaTypeHandler(MediaTypeOptions? mediaTypeOptions = null)
+  {
+      _mediaTypeOptions = mediaTypeOptions ?? new MediaTypeOptions();
+  }
+
+  protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+  {
+    if (request == null){
+      throw new ArgumentNullException(nameof(request));
+    }
+
+    var mediaTypeHandlerOption = request.GetRequestOption<MediaTypeOptions>() ?? _mediaTypeOptions;
+    
+    if (!request.Headers.Contains(MediaTypeHeaderKey) 
+    || !request.Headers.GetValues(MediaTypeHeaderKey)
+      .Any(x => mediaTypeHandlerOption.MediaTypeValue.Equals(x, StringComparison.OrdinalIgnoreCase)))
+    {
+      request.Headers.Add(MediaTypeHeaderKey, mediaTypeHandlerOption.MediaTypeValue);
+    }
+    return base.SendAsync(request, cancellationToken);
+  }
+}

--- a/generated/csharp/GitHub/Middleware/Options/MediaTypeOptions.cs
+++ b/generated/csharp/GitHub/Middleware/Options/MediaTypeOptions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Kiota.Abstractions;
+
+namespace GitHub.Octokit.Client.Middleware.Options;
+
+public class MediaTypeOptions : IRequestOption
+{
+
+  public string MediaTypeValue { get; set; } = GetMediaType();
+
+  /// <summary>
+  /// This needs to be extended to consider all the media types that are supported by the SDK
+  /// https://docs.github.com/en/rest/overview/media-types?apiVersion=2022-11-28
+  /// </summary>
+  /// <returns></returns>
+  private static string GetMediaType() => "application/vnd.github+json";
+}

--- a/generated/csharp/GitHub/Middleware/UserAgentHandler.cs
+++ b/generated/csharp/GitHub/Middleware/UserAgentHandler.cs
@@ -21,7 +21,8 @@ public class UserAgentHandler : DelegatingHandler
 
         var userAgentHandlerOption = request.GetRequestOption<UserAgentOptions>() ?? _userAgentOption;
 
-        if(!request.Headers.UserAgent.Any(x => userAgentHandlerOption.ProductName.Equals(x.Product?.Name, StringComparison.OrdinalIgnoreCase)))
+        if(!request.Headers.UserAgent
+          .Any(x => userAgentHandlerOption.ProductName.Equals(x.Product?.Name, StringComparison.OrdinalIgnoreCase)))
         {
             request.Headers.UserAgent.Add(new ProductInfoHeaderValue(userAgentHandlerOption.ProductName, userAgentHandlerOption.ProductVersion));
         }


### PR DESCRIPTION
In a future iteration all of these handler need to support being overridden - we should be able to do this by manually instantiating a Client Factory.