### PR TITLE
maint: Removes the unused part of the generate script

### DIFF
--- a/scripts/generate-csharp.sh
+++ b/scripts/generate-csharp.sh
@@ -10,8 +10,3 @@ kiota generate -l csharp --ll trace -o generated/csharp/src/GitHub -c GitHubClie
 # Build and run post-processor
 go build -o $(pwd)/post-processors/csharp/post-processor post-processors/csharp/main.go
 $(pwd)/post-processors/csharp/post-processor $(pwd)/generated/csharp/src/GitHub
-
-# Build and run the generated code and call the API via generated SDK
-cd generated/csharp/src
-dotnet restore
-dotnet run --project GitHub.Octokit.csproj


### PR DESCRIPTION
Since the SDK get's built on the CI step - the script that is used to generate the C# version of the SDK should no longer have a build step.  The project was moved from the generator and put in the dotnet-sdk.