### PR TITLE
Use --ebc on all generation runs

### DIFF
--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -37,7 +37,7 @@ jobs:
         run: go run schemas/main.go --schema-next=false
 
       - name: Run generation
-        run: time kiota generate -l csharp --ll trace -o $(pwd)/../dotnet-sdk/src/GitHub -c GitHubClient -n GitHub -d schemas/downloaded.json
+        run: kiota generate -l csharp --ll trace -o $(pwd)/../dotnet-sdk/src/GitHub -c GitHubClient -n GitHub -d schemas/downloaded.json --ebc
 
       - name: Build post-processing
         run: go build -o post-processors/csharp/post-processor post-processors/csharp/main.go

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -37,7 +37,7 @@ jobs:
         run: go run schemas/main.go --schema-next=false
 
       - name: Run generation
-        run: kiota generate -l go --ll trace -o $(pwd)/../go-sdk/pkg/github -n "github.com/octokit/go-sdk/pkg/github/" -d schemas/downloaded.json
+        run: kiota generate -l go --ll trace -o $(pwd)/../go-sdk/pkg/github -n "github.com/octokit/go-sdk/pkg/github/" -d schemas/downloaded.json --ebc
 
       - name: Build post-processing
         run: go build -o post-processors/go/post-processor post-processors/go/main.go

--- a/scripts/generate-csharp.sh
+++ b/scripts/generate-csharp.sh
@@ -5,7 +5,7 @@
 go run schemas/main.go --schema-next=false
 
 # Execute generation
-kiota generate -l csharp --ll trace -o generated/csharp/src/GitHub -c GitHubClient -n GitHub -d schemas/downloaded.json --co
+kiota generate -l csharp --ll trace -o generated/csharp/src/GitHub -c GitHubClient -n GitHub -d schemas/downloaded.json --co --ebc
 
 # Build and run post-processor
 go build -o $(pwd)/post-processors/csharp/post-processor post-processors/csharp/main.go

--- a/scripts/generate-go.sh
+++ b/scripts/generate-go.sh
@@ -9,7 +9,7 @@
 set -ex
 
 go run schemas/main.go --schema-next=false
-kiota generate -l go --ll trace -o $(pwd)/../go-sdk/pkg/github -n github.com/octokit/go-sdk/pkg/github -d schemas/downloaded.json
+kiota generate -l go --ll trace -o $(pwd)/../go-sdk/pkg/github -n github.com/octokit/go-sdk/pkg/github -d schemas/downloaded.json --ebc
 go build -o post-processors/go/post-processor post-processors/go/main.go
 cd $(pwd)/../go-sdk
 $(pwd)/../source-generator/post-processors/go/post-processor $(pwd)


### PR DESCRIPTION
Vincent mentioned we can use the `--ebc` flag, which excludes backwards compatibility from a breaking change Kiota made a while back. This will result in big changes (technically breaking, though we haven't provided any guarantees for users) and result in a lot less code, which is nice. 