### PR TITLE
Add a Kiota generated Java SDK

### DIFF
--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -1,0 +1,67 @@
+name: "Generate Java SDK"
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Run generation nightly on latest OpenAPI spec
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x.x'
+
+      - uses: actions/setup-go@v3.5.0
+        with:
+          go-version: '1.21.5'
+
+      - name: Install kiota
+        run: dotnet tool install --global Microsoft.OpenApi.Kiota --prerelease
+
+      - name: Clone the existing dotnet-sdk
+        run: |
+          cd ../
+          git clone https://github.com/octokit/java-sdk.git
+
+      - name: Download latest schema
+        run: go run schemas/main.go --schema-next=false
+
+      - name: Run generation
+        run: kiota generate -l java --ll trace -o $(pwd)/../java-sdk/src/main/java/com/github/api -c GitHubClient -n com.github.api -d schemas/downloaded.json --serializer none --deserializer none --ebc
+
+      - name: Build generated and processed SDK
+        run: |
+          cd ../java-sdk
+          mvn clean install
+
+      - uses: gr2m/create-or-update-pull-request-action@cd-path
+        if: github.event_name != 'pull_request' # do not update the SDK on PR builds
+        env:
+          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+        with:
+          title: "Changes in generated code"
+          body: >
+            The latest OpenAPI spec resulted in changes to the generated code. Please review, set an applicable
+            commit message, merge, and tag a release as appropriate.
+          branch: "generated-code-update"
+          author: "Octokit Bot <octokitbot@martynus.net>"
+          commit-message: "New updates to generated code"
+          repository: "octokit/java-sdk"
+          path-to-cd-to: "../java-sdk"

--- a/scripts/generate-java.sh
+++ b/scripts/generate-java.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+./scripts/install-tools.sh
+
+go run schemas/main.go --schema-next=false
+
+# Execute generation
+kiota generate -l java --ll trace -o generated/Java/src/main/java/com/github/api -c GitHubClient -n com.github.api -d schemas/downloaded.json --serializer none --deserializer none --co --ebc

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -4,7 +4,7 @@
 KIOTA_TOOL_NAME="microsoft.openapi.kiota"
 # This version can only increase, never decrease. If you want to use a lower version, you need to uninstall the tool first.
 # dotnet tool uninstall Microsoft.OpenApi.Kiota --global
-KIOTA_TOOL_VERSION="v1.9.0-preview.202311300001"
+KIOTA_TOOL_VERSION="v1.11.1"
 
 # Check if the tool is installed globally
 if dotnet tool list -g | grep -q $KIOTA_TOOL_NAME; then


### PR DESCRIPTION
Hi @kfcampbell and @nickfloyd 👋 ,

after the work we have done in Kiota on Java it would be great to start distributing a Java SDK 😄 
Here I started to spearhead the effort, but it will require some help on your side to be finalized, e.g. creating the `java-sdk` repository.

The generated code can be compiled using Maven with a minimal `pom.xml` like:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.github.api</groupId>
    <artifactId>github-java-sdk</artifactId>
    <version>0.0.1</version>
    <properties>
        <kiota.libs.version>0.12.1</kiota.libs.version>
        <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
    </properties>
    <dependencies>
        <dependency>
            <groupId>com.microsoft.kiota</groupId>
            <artifactId>microsoft-kiota-abstractions</artifactId>
            <version>${kiota.libs.version}</version>
        </dependency>
        <dependency>
            <groupId>jakarta.annotation</groupId>
            <artifactId>jakarta.annotation-api</artifactId>
            <version>${jakarta.annotation.version}</version>
        </dependency>
    </dependencies>
</project>
```

Happy to answer any questions and assist in the process!