### PR TITLE
Goodbye pkg directory

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -37,7 +37,7 @@ jobs:
         run: go run schemas/main.go --schema-next=false
 
       - name: Run generation
-        run: kiota generate -l go --ll trace -o $(pwd)/../go-sdk/pkg/github -n "github.com/octokit/go-sdk/pkg/github/" -d schemas/downloaded.json --ebc
+        run: kiota generate -l go --ll trace -o $(pwd)/../go-sdk/github -n "github.com/octokit/go-sdk/github/" -d schemas/downloaded.json --ebc
 
       - name: Build post-processing
         run: go build -o post-processors/go/post-processor post-processors/go/main.go

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -74,13 +74,13 @@
     # "/" will be replaced by current OS file path separator to properly work
     # on Windows.
 
-    # skipping pkg/github/markdown/raw_request_builder.go's error of
+    # skipping github/markdown/raw_request_builder.go's error of
     # "G104: Errors unhandled.
     # "requestInfo.SetContentFromScalar(ctx, m.BaseRequestBuilder.RequestAdapter, "text/plain", body)"
     # because it happens due to generation and is not quickly fixed.
     # 'exclude' cannot be used here because the error text applies to many possible errors
     # and we don't want to ignore other instances of this error
-    skip-files = [ "pkg/github/markdown/raw_request_builder.go" ]
+    skip-files = [ "github/markdown/raw_request_builder.go" ]
 
     # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
     # If invoked with -mod=readonly, the go command is disallowed from the implicit

--- a/scripts/generate-go.sh
+++ b/scripts/generate-go.sh
@@ -9,7 +9,7 @@
 set -ex
 
 go run schemas/main.go --schema-next=false
-kiota generate -l go --ll trace -o $(pwd)/../go-sdk/pkg/github -n github.com/octokit/go-sdk/pkg/github -d schemas/downloaded.json --ebc
+kiota generate -l go --ll trace -o $(pwd)/../go-sdk/github -n github.com/octokit/go-sdk/github -d schemas/downloaded.json --ebc
 go build -o post-processors/go/post-processor post-processors/go/main.go
 cd $(pwd)/../go-sdk
 $(pwd)/../source-generator/post-processors/go/post-processor $(pwd)


### PR DESCRIPTION
I've been thinking about this a lot. There's no question I've been one of the more staunch defenders of the `pkg` directory; I like the cleanliness of a root directory with the source code tucked into a neatly identifiable folder. 

However, there's also no question I've been outvoted on this front, and as I work through what nice client abstractions might look like in https://github.com/octokit/go-sdk/pull/52, I'm debating going the other way. First, there's the repetition in any top-level Go file: `package pkg`, which is ugly (though it could be remedied by switching to `src` or something similar). Second, I was clinging to something that isn't that big of a deal: inside the `pkg` directory of go-sdk on the rate-limiting branch, there's only four other directories, which even if expanded wouldn't be the end of the world.

Also, I've read our esteemed GitHub colleague Dave Cheney's post [here](https://dave.cheney.net/practical-go/presentations/gophercon-israel.html#_consider_fewer_larger_packages), which mentions: 

> Possibly because of the early use of a pkg/ directory to hold package—​and the corresponding cmd/ directory to hold commands (package main) this practice of putting your packages in an empty pkg/ directory has spread to other Go projects. This practice was never a recommendation, just a result of the original Makefile based build system.

> In September 2014, the stdlib moved away from storing package code in an otherwise empty pkg/ directory, and you should follow their lead. Other than a superficial symetary [sic] with cmd/ putting packages in a pkg/ directory is needless boilerplate and distracts from the potentially more useful internal/ directory.

One thing that does concern me a bit is that removing the `pkg` directory would mean any code currently in Go files immediately belonging to that folder would have to find a different directory in order to continue to be exported. This could lead to repetition or potentially poor naming elsewhere as package names are forced. 