### PR TITLE
Enable building GHES specific clients

### DIFF
--- a/schemas/main.go
+++ b/schemas/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -10,12 +11,14 @@ import (
 
 var useSchemaNext bool
 var ghes bool
+var ghesVersion string
 
 // Normally I hate using init() but the docs [here](https://pkg.go.dev/flag)
 // recommend it so this usage is safe.
 func init() {
 	flag.BoolVar(&useSchemaNext, "schema-next", false, "Set to true using --schema-next=true to use the descriptions-next directory for schema downloads")
 	flag.BoolVar(&ghes, "ghes", false, "Set to true using --ghes=true to pull down the descriptions in ghes-3.13")
+	flag.StringVar(&ghesVersion, "ghes-version", "3.12", "The version of GHES to generate for. (default 3.12)")
 }
 
 func main() {
@@ -40,8 +43,8 @@ func realMain() error {
 		logMsg = "Downloading latest schema from descriptions-next directory"
 		url = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.json"
 	} else if ghes {
-		logMsg = "Downloading the GHES 3.12 schema"
-		url = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/ghes-3.12/ghes-3.12.json"
+		logMsg = fmt.Sprintf("Downloading the GHES %v schema", ghesVersion)
+		url = fmt.Sprintf("https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/ghes-%v/ghes-%v.json", ghesVersion, ghesVersion)
 	}
 
 	log.Printf(logMsg)

--- a/schemas/main.go
+++ b/schemas/main.go
@@ -9,11 +9,13 @@ import (
 )
 
 var useSchemaNext bool
+var ghes bool
 
 // Normally I hate using init() but the docs [here](https://pkg.go.dev/flag)
 // recommend it so this usage is safe.
 func init() {
 	flag.BoolVar(&useSchemaNext, "schema-next", false, "Set to true using --schema-next=true to use the descriptions-next directory for schema downloads")
+	flag.BoolVar(&ghes, "ghes", false, "Set to true using --ghes=true to pull down the descriptions in ghes-3.13")
 }
 
 func main() {
@@ -37,6 +39,9 @@ func realMain() error {
 	if useSchemaNext {
 		logMsg = "Downloading latest schema from descriptions-next directory"
 		url = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.json"
+	} else if ghes {
+		logMsg = "Downloading the GHES 3.12 schema"
+		url = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/ghes-3.12/ghes-3.12.json"
 	}
 
 	log.Printf(logMsg)

--- a/scripts/generate-go.sh
+++ b/scripts/generate-go.sh
@@ -9,13 +9,21 @@
 set -ex
 
 if [ -z "$1" ]; then 
+  gen_path="../go-sdk"
   go run schemas/main.go --schema-next=false
 elif [ "$1" = "ghes" ]; then
-  go run schemas/main.go --schema-next=false --ghes=true
+  if [ -z "$2" ]; then
+    echo "generating for GHES requires that you specify a version as the second argument. ex $0 ghes 3.12"
+    exit 1
+  else
+    ghes_version=$2
+    gen_path="../go-sdk-ghes"
+    go run schemas/main.go --schema-next=false --ghes=true --ghes-version=3.12
+  fi
 fi
 
-kiota generate -l go --ll trace -o $(pwd)/../go-sdk/pkg/github -n github.com/octokit/go-sdk/pkg/github -d schemas/downloaded.json --ebc
+kiota generate -l go --ll trace -o $(pwd)/${gen_path}/pkg/github -n github.com/octokit/go-sdk/pkg/github -d schemas/downloaded.json --ebc
 go build -o post-processors/go/post-processor post-processors/go/main.go
-cd $(pwd)/../go-sdk
+cd $(pwd)/${gen_path}
 $(pwd)/../source-generator/post-processors/go/post-processor $(pwd)
 go build ./...

--- a/scripts/generate-go.sh
+++ b/scripts/generate-go.sh
@@ -8,7 +8,12 @@
 
 set -ex
 
-go run schemas/main.go --schema-next=false
+if [ -z "$1" ]; then 
+  go run schemas/main.go --schema-next=false
+elif [ "$1" = "ghes" ]; then
+  go run schemas/main.go --schema-next=false --ghes=true
+fi
+
 kiota generate -l go --ll trace -o $(pwd)/../go-sdk/pkg/github -n github.com/octokit/go-sdk/pkg/github -d schemas/downloaded.json --ebc
 go build -o post-processors/go/post-processor post-processors/go/main.go
 cd $(pwd)/../go-sdk


### PR DESCRIPTION
Adds arguments to allow the caller to specify building for GHES as well as which version of the API spec to build from.

ex
`./script/generate-go.sh ghes 3.12` 

Passing `ghes` without a version will result in:

```
@thorrsson ➜ /workspaces/source-generator (enable-ghes) $ ./scripts/generate-go.sh ghes 
microsoft.openapi.kiota is installed. Updating to sync with the required version
Tool 'microsoft.openapi.kiota' was reinstalled with the prerelease version (version '1.13.0-preview.202403280001').
+ [ -z ghes ]
+ [ ghes = ghes ]
+ [ -z  ]
+ echo generating for GHES requires that you specify a version as the second argument. ex ./scripts/generate-go.sh ghes 3.12
generating for GHES requires that you specify a version as the second argument. ex ./scripts/generate-go.sh ghes 3.12
+ exit 1
```
