### PR TITLE
Build fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "mode": "auto",
       "program": "${workspaceFolder}/post-processors/go/main.go",
       "args": [
-        "${workspaceFolder}/generated/go"
+        "${workspaceFolder}/../go-sdk"
       ]
     },
     {
@@ -21,7 +21,7 @@
       "mode": "auto",
       "program": "${workspaceFolder}/post-processors/csharp/main.go",
       "args": [
-        "${workspaceFolder}/generated/csharp"
+        "${workspaceFolder}/../dotnet-sdk"
       ]
     },
   ]

--- a/post-processors/csharp/main.go
+++ b/post-processors/csharp/main.go
@@ -181,11 +181,6 @@ func fixKiotaTeamErrors(inputFile string, filePath string) string {
 }
 
 func fixKiotaUntypedNodeErrors(inputFile string, filePath string) string {
-	// toreplace:
-	// SendAsync<UntypedNode>(requestInfo, default, cancellationToken)
-	// replaceWith:
-	// SendAsync<UntypedNode>(requestInfo, UntypedNode.CreateFromDiscriminatorValue, default, cancellationToken)
-
 	if !strings.Contains(filePath, "Repos/Item/Item/Stats/Punch_card/Punch_cardRequestBuilder.cs") &&
 		!strings.Contains(filePath, "Repos/Item/Item/Stats/Code_frequency/Code_frequencyRequestBuilder.cs") {
 		return inputFile

--- a/post-processors/go/main.go
+++ b/post-processors/go/main.go
@@ -42,6 +42,7 @@ func run() error {
 		}
 
 		fileContents = fixKiotaNonDeterminism(fileContents, file.Name())
+		fileContents = fixKiotaFileNameTypeNameError(fileContents, file.Name())
 
 		err = os.WriteFile(path, []byte(fileContents), 0600)
 		if err != nil {
@@ -169,6 +170,22 @@ type ItemStarredRepositoryable interface {
     i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.AdditionalDataHolder
     i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable
 }`
+	if strings.Contains(inputFile, toReplace) {
+		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
+	}
+	return inputFile
+}
+
+func fixKiotaFileNameTypeNameError(inputFile string, fileName string) string {
+	if !strings.Contains(fileName, "code_scanning_variant_analysis.go") {
+		return inputFile
+	}
+
+	// Kiota's generation gives the file name rather than the type name in this
+	// specific case, so this workaround fixes it.
+	toReplace := "CodeScanningVariantAnalysis_status"
+	replaceWith := "CodeScanningVariantAnalysisStatus"
+
 	if strings.Contains(inputFile, toReplace) {
 		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
 	}

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -7,7 +7,7 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56
 KIOTA_TOOL_NAME="microsoft.openapi.kiota"
 # This version can only increase, never decrease. If you want to use a lower version, you need to uninstall the tool first.
 # dotnet tool uninstall Microsoft.OpenApi.Kiota --global
-KIOTA_TOOL_VERSION="v1.9.0-preview.202311300001"
+KIOTA_TOOL_VERSION="1.15.0-preview.202405160001"
 
 # Check if the tool is installed globally
 if dotnet tool list -g | grep -q $KIOTA_TOOL_NAME; then


### PR DESCRIPTION
When looking at the dotnet-sdk this morning, I noticed we hadn't seen a new update recently. I checked the [source-generator's Actions](https://github.com/octokit/source-generator/actions) and saw both Go and .NET generation has been broken for about a week. 

This PR adds workarounds that fix (hopefully temporary) breakages in Kiota. Next I need to file issues for these problems. 