### PR TITLE
Don't use prerelease versions of Kiota

### DIFF
--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.21.5'
 
       - name: Install kiota
-        run: dotnet tool install --global Microsoft.OpenApi.Kiota --prerelease
+        run: dotnet tool install --global Microsoft.OpenApi.Kiota
 
       - name: Clone the existing dotnet-sdk
         run: |

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.21.5'
 
       - name: Install kiota
-        run: dotnet tool install --global Microsoft.OpenApi.Kiota --prerelease
+        run: dotnet tool install --global Microsoft.OpenApi.Kiota
 
       - name: Clone the existing go-sdk
         run: |

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -7,7 +7,7 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56
 KIOTA_TOOL_NAME="microsoft.openapi.kiota"
 # This version can only increase, never decrease. If you want to use a lower version, you need to uninstall the tool first.
 # dotnet tool uninstall Microsoft.OpenApi.Kiota --global
-KIOTA_TOOL_VERSION="1.15.0-preview.202405160001"
+KIOTA_TOOL_VERSION="1.14.0"
 
 # Check if the tool is installed globally
 if dotnet tool list -g | grep -q $KIOTA_TOOL_NAME; then


### PR DESCRIPTION
We've been running into a lot of errors and failed builds recently driven by using prerelease builds of Kiota. In order to stabilize our CI process and ensure timely delivery of new SDKs, let's switch to using regular builds of Kiota. 