### PR TITLE
Remove additional uses of relative paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "mode": "auto",
       "program": "${workspaceFolder}/post-processors/go/main.go",
       "args": [
-        "${workspaceFolder}/../go-sdk"
+        "${workspaceFolder}/stage/go-sdk"
       ]
     },
     {
@@ -21,7 +21,7 @@
       "mode": "auto",
       "program": "${workspaceFolder}/post-processors/csharp/main.go",
       "args": [
-        "${workspaceFolder}/../dotnet-sdk"
+        "${workspaceFolder}/stage/dotnet-sdk"
       ]
     },
   ]

--- a/post-processors/csharp/main.go
+++ b/post-processors/csharp/main.go
@@ -60,7 +60,7 @@ func run() error {
 	}
 
 	initialDir, _ := os.Getwd() // Used for the dotnet add package command and traversal
-	packageInstallDir := fmt.Sprintf("%s/../dotnet-sdk/src", initialDir)
+	packageInstallDir := fmt.Sprintf("%s/stage/dotnet-sdk/src", initialDir)
 
 	cmd := exec.Command("kiota", "info", "-l", "CSharp", "--json")
 	cmd.Dir = dirPath

--- a/stage/dotnet-sdk/src/GitHub.Octokit.SDK.csproj
+++ b/stage/dotnet-sdk/src/GitHub.Octokit.SDK.csproj
@@ -34,10 +34,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.1" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.9.0" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.4.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.8.4" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.6" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.2.3" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.4" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.5" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.5" />


### PR DESCRIPTION
When troubleshooting the Kiota upgrade, I noticed [.NET builds](https://github.com/octokit/source-generator/actions/runs/9491596031/job/26157323607) were erroneously succeeding. We were seeing output like `chdir /home/runner/work/source-generator/source-generator/../dotnet-sdk/src: no such file or directory`. 

This fixes that path (and a couple other instances I found) to use the new staging locations. The .csproj changes are purely a result of rerunning `scripts/generate-dotnet.sh` with Kiota v1.14.0 installed, so IMO they're worth keeping. 