### PR TITLE
Fix dotnet-sdk sample

### DIFF
--- a/stage/dotnet-sdk/README.md
+++ b/stage/dotnet-sdk/README.md
@@ -19,10 +19,10 @@ To install the package, you can use either of the following options:
 ```csharp
 using GitHub;
 using GitHub.Octokit.Client;
-using GitHub.Octokit.Authentication;
+using GitHub.Octokit.Client.Authentication;
 
 var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "";
-var request = RequestAdapter.Create(new TokenAuthenticationProvider("Octokit.Gen", token));
+var request = RequestAdapter.Create(new TokenAuthProvider(new TokenProvider(token)));
 var gitHubClient = new GitHubClient(request);
 
 var pullRequests = await gitHubClient.Repos["octokit"]["octokit.net"].Pulls.GetAsync();


### PR DESCRIPTION
This PR replays https://github.com/octokit/dotnet-sdk/pull/89 in the source-generator. I noticed when reviewing https://github.com/octokit/dotnet-sdk/pull/90 that those changes were going to be undone. 

In the future once this architecture is more fully fleshed out, we'll have to be more careful with our documentation so contributors (including ourselves) understand the relationship between the repositories and know where to make changes appropriately. 