### PR TITLE
REPO_NAME env var fix

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -50,6 +50,7 @@ jobs:
         if: github.event_name != 'pull_request' # do not update the SDK on PR builds
         env:
           GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+          REPO_NAME: ${{ env.REPO_NAME }}
         with:
           title: "Changes in generated code"
           body: >
@@ -58,5 +59,5 @@ jobs:
           branch: "generated-code-update"
           author: "Octokit Bot <octokitbot@martynus.net>"
           commit-message: "New updates to generated code"
-          repository: "octokit/$REPO_NAME"
-          path-to-cd-to: "../$REPO_NAME"
+          repository: "octokit/${{ env.REPO_NAME }}"
+          path-to-cd-to: "../${{ env.REPO_NAME }}"

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -51,6 +51,7 @@ jobs:
         if: github.event_name != 'pull_request' # do not update the SDK on PR builds
         env:
           GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+          REPO_NAME: ${{ env.REPO_NAME }}
         with:
           title: "Changes in generated code"
           body: >

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -60,5 +60,5 @@ jobs:
           branch: "generated-code-update"
           author: "Octokit Bot <octokitbot@martynus.net>"
           commit-message: "New updates to generated code"
-          repository: "octokit/$REPO_NAME"
-          path-to-cd-to: "../$REPO_NAME"
+          repository: "octokit/${{ env.REPO_NAME }}"
+          path-to-cd-to: "../${{ env.REPO_NAME }}"


### PR DESCRIPTION
Fix for the issue breaking PRs we're seeing [here](https://github.com/octokit/source-generator/actions/runs/9865896920/job/27243696681#step:9:69) and [here](https://github.com/octokit/source-generator/actions/runs/9866081156/job/27244216071#step:8:1), for example.

Actions doesn't automatically pass environment variables to reusable workflows, which is causing PR creation to 404. 