### PR TITLE
Note octokit.net in READMEs

### DIFF
--- a/stage/dotnet/dotnet-sdk-enterprise-cloud/README.md
+++ b/stage/dotnet/dotnet-sdk-enterprise-cloud/README.md
@@ -14,6 +14,9 @@ You may also want:
 		- [dotnet-sdk-enterprise-cloud repository](https://github.com/octokit/dotnet-sdk-enterprise-cloud)
 	- For GitHub Enterprise Server
 		- [dotnet-sdk-enterprise-server repository](https://github.com/octokit/dotnet-sdk-enterprise-server)
+    - For our classic non-generated, hand-maintained Octokit.net project
+		- [Octokit.net repository](https://github.com/octokit/octokit.net)
+		- For why we're building generative SDKs, see [Why a generated SDK?](#why-a-generated-sdk) below
 - Go
 	- For the standard GitHub.com product
 		- [go-sdk repository](https://github.com/octokit/go-sdk)

--- a/stage/dotnet/dotnet-sdk-enterprise-server/README.md
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/README.md
@@ -14,6 +14,9 @@ You may also want:
 		- [dotnet-sdk-enterprise-cloud repository](https://github.com/octokit/dotnet-sdk-enterprise-cloud)
 	- For GitHub Enterprise Server
 		- [dotnet-sdk-enterprise-server repository](https://github.com/octokit/dotnet-sdk-enterprise-server)
+	- For our classic non-generated, hand-maintained Octokit.net project
+		- [Octokit.net repository](https://github.com/octokit/octokit.net)
+		- For why we're building generative SDKs, see [Why a generated SDK?](#why-a-generated-sdk) below
 - Go
 	- For the standard GitHub.com product
 		- [go-sdk repository](https://github.com/octokit/go-sdk)

--- a/stage/dotnet/dotnet-sdk/README.md
+++ b/stage/dotnet/dotnet-sdk/README.md
@@ -24,6 +24,9 @@ You may also want:
 	- For GitHub Enterprise Server
 		- [go-sdk-enterprise-server repository](https://github.com/octokit/go-sdk-enterprise-server)
 		- [pkg.go.dev docs link](https://pkg.go.dev/github.com/octokit/go-sdk-enterprise-server)
+    - For our classic non-generated, hand-maintained Octokit.net project
+		- [Octokit.net repository](https://github.com/octokit/octokit.net)
+		- For why we're building generative SDKs, see [Why a generated SDK?](#why-a-generated-sdk) below
 - [source-generator](https://github.com/octokit/source-generator) (the repository that creates these generated SDKs)
 	- Contributions to this repository should take place in source-generator instead, as they'll be distributed here through mechanisms there.
 

--- a/stage/go/go-sdk-enterprise-cloud/README.md
+++ b/stage/go/go-sdk-enterprise-cloud/README.md
@@ -22,6 +22,9 @@ You may also want:
 		- [dotnet-sdk-enterprise-cloud repository](https://github.com/octokit/dotnet-sdk-enterprise-cloud)
 	- For GitHub Enterprise Server
 		- [dotnet-sdk-enterprise-server repository](https://github.com/octokit/dotnet-sdk-enterprise-server)
+	- For our classic non-generated, hand-maintained Octokit.net project
+		- [Octokit.net repository](https://github.com/octokit/octokit.net)
+		- For why we're building generative SDKs, see [Why a generated SDK?](#why-a-generated-sdk) below
 - [source-generator](https://github.com/octokit/source-generator) (the repository that creates these generated SDKs)
 	- Contributions to this repository should take place in source-generator instead, as they'll be distributed here through mechanisms there.
 

--- a/stage/go/go-sdk-enterprise-server/README.md
+++ b/stage/go/go-sdk-enterprise-server/README.md
@@ -22,6 +22,9 @@ You may also want:
 		- [dotnet-sdk-enterprise-cloud repository](https://github.com/octokit/dotnet-sdk-enterprise-cloud)
 	- For GitHub Enterprise Server
 		- [dotnet-sdk-enterprise-server repository](https://github.com/octokit/dotnet-sdk-enterprise-server)
+	- For our classic non-generated, hand-maintained Octokit.net project
+		- [Octokit.net repository](https://github.com/octokit/octokit.net)
+		- For why we're building generative SDKs, see [Why a generated SDK?](#why-a-generated-sdk) below
 - [source-generator](https://github.com/octokit/source-generator) (the repository that creates these generated SDKs)
 	- Contributions to this repository should take place in source-generator instead, as they'll be distributed here through mechanisms there.
 

--- a/stage/go/go-sdk/README.md
+++ b/stage/go/go-sdk/README.md
@@ -22,6 +22,9 @@ You may also want:
 		- [dotnet-sdk-enterprise-cloud repository](https://github.com/octokit/dotnet-sdk-enterprise-cloud)
 	- For GitHub Enterprise Server
 		- [dotnet-sdk-enterprise-server repository](https://github.com/octokit/dotnet-sdk-enterprise-server)
+	- For our classic non-generated, hand-maintained Octokit.net project
+		- [Octokit.net repository](https://github.com/octokit/octokit.net)
+		- For why we're building generative SDKs, see [Why a generated SDK?](#why-a-generated-sdk) below
 - [source-generator](https://github.com/octokit/source-generator) (the repository that creates these generated SDKs)
 	- Contributions to this repository should take place in source-generator instead, as they'll be distributed here through mechanisms there.
 


### PR DESCRIPTION
Issues like https://github.com/octokit/dotnet-sdk/issues/100 are the result of a simple misunderstanding between SDK offerings. This small README update attempts to clarify that by noting Octokit.net and its differences before linking to our reasoning for why we're building a generated SDK. 