### PR TITLE
Fix branch update permissions errors

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -121,8 +121,8 @@ jobs:
             commit message, merge, and tag a release as appropriate.
           base-branch: ${{ matrix.version }}
           branch: "generated-code-update-${{ matrix.version }}"
-          author: "Octokit Bot <security+octokitbot@github.com>"
-          # author: "Octokit Bot <octokitbot@martynus.net>"
+          # author: "Octokit Bot <security+octokitbot@github.com>"
+          author: "Octokit Bot <octokitbot@martynus.net>"
           commit-message: "New updates to generated code"
           repository: "octokit/dotnet-sdk-enterprise-server"
           path-to-cd-to: "../dotnet-sdk-enterprise-server"

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -37,17 +37,17 @@ jobs:
 
       - name: Run scripts/generate-dotnet.sh
         run: scripts/generate-dotnet.sh ${{ matrix.platform }}
-      
+
       - name: Clean up build artifacts before syncing
         run: dotnet clean stage/dotnet/$REPO_NAME/GitHub.Octokit.sln
-        
+
       - name: Clone the existing repository
         run: |
           cd ../
           git clone https://github.com/octokit/$REPO_NAME.git
 
       - name: Copy generated code to dotnet-sdk
-        run: | 
+        run: |
           cp -rf stage/dotnet/$REPO_NAME/. ../$REPO_NAME/ # copy everything
           rsync -av --delete stage/dotnet/$REPO_NAME/src/ ../$REPO_NAME/src/ # delete files that are not generated
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run scripts/generate-dotnet.sh
         run: scripts/generate-dotnet.sh ghes ${{ matrix.version }}
-      
+
       - name: Clean up build artifacts before syncing
         run: dotnet clean stage/dotnet/dotnet-sdk-enterprise-server/GitHub.Octokit.sln
 
@@ -112,7 +112,8 @@ jobs:
       - uses: gr2m/create-or-update-pull-request-action@cd-path
         if: github.event_name != 'pull_request' # do not update the SDK on PR builds
         env:
-          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_SDK_PAT }}
+          # GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_SDK_PAT }}
+          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
         with:
           title: "GHES ${{ matrix.version}}: Changes in generated code"
           body: >
@@ -121,6 +122,7 @@ jobs:
           base-branch: ${{ matrix.version }}
           branch: "generated-code-update-${{ matrix.version }}"
           author: "Octokit Bot <security+octokitbot@github.com>"
+          # author: "Octokit Bot <octokitbot@martynus.net>"
           commit-message: "New updates to generated code"
           repository: "octokit/dotnet-sdk-enterprise-server"
           path-to-cd-to: "../dotnet-sdk-enterprise-server"

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -97,11 +97,13 @@ jobs:
           cd ../
           git clone https://github.com/octokit/dotnet-sdk-enterprise-server.git
           cd dotnet-sdk-enterprise-server
-          if git show-ref --verify --quiet refs/heads/${{ matrix.version }}; then
-            echo "Branch ${{ matrix.version }} already exists; skipping creation"
+          git fetch origin
+          if git show-ref --verify --quiet refs/remotes/origin/${{ matrix.version }}; then
+            git switch -c ${{ matrix.version }} --track origin/${{ matrix.version }}
+            echo "Branch ${{ matrix.version }} already exists; skipping creation and fetching from remote"
           else
             git switch -c ${{ matrix.version }}
-            echo "Branch ${{ matrix.version }} created"
+            echo "Branch ${{ matrix.version }} does not exist on remote; created locally"
             git switch -
           fi
           cd ../

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -98,9 +98,11 @@ jobs:
           git clone https://github.com/octokit/dotnet-sdk-enterprise-server.git
           cd dotnet-sdk-enterprise-server
           if git show-ref --verify --quiet refs/heads/${{ matrix.version }}; then
-            git switch ${{ matrix.version }}
+            echo "Branch ${{ matrix.version }} already exists; skipping creation"
           else
             git switch -c ${{ matrix.version }}
+            echo "Branch ${{ matrix.version }} created"
+            git switch -
           fi
           cd ../
 
@@ -112,8 +114,7 @@ jobs:
       - uses: gr2m/create-or-update-pull-request-action@cd-path
         if: github.event_name != 'pull_request' # do not update the SDK on PR builds
         env:
-          # GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_SDK_PAT }}
-          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_SDK_PAT }}
         with:
           title: "GHES ${{ matrix.version}}: Changes in generated code"
           body: >
@@ -121,8 +122,7 @@ jobs:
             commit message, merge, and tag a release as appropriate.
           base-branch: ${{ matrix.version }}
           branch: "generated-code-update-${{ matrix.version }}"
-          # author: "Octokit Bot <security+octokitbot@github.com>"
-          author: "Octokit Bot <octokitbot@martynus.net>"
+          author: "Octokit Bot <security+octokitbot@github.com>"
           commit-message: "New updates to generated code"
           repository: "octokit/dotnet-sdk-enterprise-server"
           path-to-cd-to: "../dotnet-sdk-enterprise-server"

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -114,7 +114,7 @@ jobs:
             commit message, merge, and tag a release as appropriate.
           base-branch: ${{ matrix.version }}
           branch: "generated-code-update-${{ matrix.version }}"
-          author: "Octokit Bot <security+octokitbot@github.com>"
+          author: "Octokit Bot <octokitbot@martynus.net>"
           commit-message: "New updates to generated code"
           repository: "octokit/go-sdk-enterprise-server"
           path-to-cd-to: "../go-sdk-enterprise-server"

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: gr2m/create-or-update-pull-request-action@cd-path
         if: github.event_name != 'pull_request' # do not update the SDK on PR builds
         env:
-          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_SDK_PAT }}
         with:
           title: "GHES ${{ matrix.version}}: Changes in generated code"
           body: >
@@ -114,7 +114,7 @@ jobs:
             commit message, merge, and tag a release as appropriate.
           base-branch: ${{ matrix.version }}
           branch: "generated-code-update-${{ matrix.version }}"
-          author: "Octokit Bot <octokitbot@martynus.net>"
+          author: "Octokit Bot <security+octokitbot@github.com>"
           commit-message: "New updates to generated code"
           repository: "octokit/go-sdk-enterprise-server"
           path-to-cd-to: "../go-sdk-enterprise-server"

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: gr2m/create-or-update-pull-request-action@cd-path
         if: github.event_name != 'pull_request' # do not update the SDK on PR builds
         env:
-          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_SDK_PAT }}
+          GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
         with:
           title: "GHES ${{ matrix.version}}: Changes in generated code"
           body: >

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -91,10 +91,13 @@ jobs:
           cd ../
           git clone https://github.com/octokit/go-sdk-enterprise-server.git
           cd go-sdk-enterprise-server
-          if git show-ref --verify --quiet refs/heads/${{ matrix.version }}; then
-            git switch ${{ matrix.version }}
+          if git show-ref --verify --quiet refs/remotes/origin/${{ matrix.version }}; then
+            git switch -c ${{ matrix.version }} --track origin/${{ matrix.version }}
+            echo "Branch ${{ matrix.version }} already exists; skipping creation and fetching from remote"
           else
             git switch -c ${{ matrix.version }}
+            echo "Branch ${{ matrix.version }} does not exist on remote; created locally"
+            git switch -
           fi
           cd ../
 


### PR DESCRIPTION
We've been seeing EPERM errors on branch updates for dotnet-sdk-enterprise-server. This was due to a mistake in the way the branch was being created locally: since the check was only seeing the branch not existing locally, not on the remote, a new branch was always being created from the main branch. When fetching that branch from the remote and trying to replay those changes on top of the locally created branch, conflicts arose. 

This PR should fix those changes, as demonstrated by a failing build in [.NET here](https://github.com/octokit/source-generator/actions/runs/10099817943) followed by a successful [.NET build here](https://github.com/octokit/source-generator/actions/runs/10102017040) and a successful Go build [here](https://github.com/octokit/source-generator/actions/runs/10102015333). 