### PR TITLE
Adds the build and publish logic for each GHES branch 

### DIFF
--- a/scripts/generate-dotnet.sh
+++ b/scripts/generate-dotnet.sh
@@ -53,8 +53,7 @@ elif [ "$PLATFORM" = "ghes" ]; then
     sed -i "s|<PackageId>GitHub.Octokit.GHES.SDK</PackageId>|<PackageId>GitHub.Octokit.GHES.SDK.$VERSION</PackageId>|" "$CSPROJ_PACKAGE_FILE"
     echo "Updated <PackageId> to GitHub.Octokit.GHES.SDK.$VERSION in $CSPROJ_PACKAGE_FILE"
 
-    # Update the branches node in the publish.yml file to include the current version only
-    # This will set the branches node to an array containing only the new branch name, effectively replacing anything under the node.
+    # Update the branches node in the build.yml file to include the current version only
     sed -i'' "s/- main/- $VERSION/" "$BUILD_YAML"
     echo "Branch replaced with version $VERSION in $BUILD_YAML."
 else

--- a/scripts/generate-dotnet.sh
+++ b/scripts/generate-dotnet.sh
@@ -61,8 +61,6 @@ else
 	NAMESPACE="dotnet-sdk"
 fi
 
-
-
 go run schemas/main.go --schema-next=false --platform=$PLATFORM --version=$VERSION
 kiota generate -l csharp --ll Information -o $(pwd)/stage/dotnet/$NAMESPACE/src/GitHub -c GitHubClient -n GitHub -d $SCHEMA_FILE --ebc
 go build -o $(pwd)/post-processors/csharp/post-processor post-processors/csharp/main.go

--- a/scripts/generate-dotnet.sh
+++ b/scripts/generate-dotnet.sh
@@ -47,7 +47,7 @@ if [ "$PLATFORM" = "ghec" ]; then
 elif [ "$PLATFORM" = "ghes" ]; then
 	NAMESPACE="dotnet-sdk-enterprise-server"
     CSPROJ_PACKAGE_FILE="stage/dotnet/$NAMESPACE/src/GitHub.Octokit.GHES.SDK.csproj"
-    PUBLISH_YAML="stage/dotnet/$NAMESPACE/.github/workflows/publish.yml"
+    BUILD_YAML="stage/dotnet/$NAMESPACE/.github/workflows/build.yml"
 
     # Update the PackageId in the .csproj file to include the version
     sed -i "s|<PackageId>GitHub.Octokit.GHES.SDK</PackageId>|<PackageId>GitHub.Octokit.GHES.SDK.$VERSION</PackageId>|" "$CSPROJ_PACKAGE_FILE"
@@ -55,8 +55,8 @@ elif [ "$PLATFORM" = "ghes" ]; then
 
     # Update the branches node in the publish.yml file to include the current version only
     # This will set the branches node to an array containing only the new branch name, effectively replacing anything under the node.
-    sed -i'' "s/- main/- $VERSION/" "$PUBLISH_YAML"
-    echo "Branch replaced with version $VERSION in $PUBLISH_YAML."
+    sed -i'' "s/- main/- $VERSION/" "$BUILD_YAML"
+    echo "Branch replaced with version $VERSION in $BUILD_YAML."
 else
 	NAMESPACE="dotnet-sdk"
 fi

--- a/scripts/generate-dotnet.sh
+++ b/scripts/generate-dotnet.sh
@@ -55,7 +55,7 @@ elif [ "$PLATFORM" = "ghes" ]; then
 
     # Update the branches node in the publish.yml file to include the current version only
     # This will set the branches node to an array containing only the new branch name, effectively replacing anything under the node.
-    sed -i'' -e "s/- main/- $VERSION/" "$PUBLISH_YAML"
+    sed -i'' "s/- main/- $VERSION/" "$PUBLISH_YAML"
     echo "Branch replaced with version $VERSION in $PUBLISH_YAML."
 else
 	NAMESPACE="dotnet-sdk"

--- a/scripts/generate-dotnet.sh
+++ b/scripts/generate-dotnet.sh
@@ -55,22 +55,8 @@ elif [ "$PLATFORM" = "ghes" ]; then
 
     # Update the branches node in the publish.yml file to include the current version only
     # This will set the branches node to an array containing only the new branch name, effectively replacing anything under the node.
-    awk -v branch="$VERSION" '
-    BEGIN { inside_branches = 0 }
-    /^branches:/ {
-        print
-        print "  - " branch
-        inside_branches = 1
-        next
-    }
-    inside_branches && /^ *- / {
-        next
-    }
-    { 
-        inside_branches = 0
-        print 
-    }
-    ' "$PUBLISH_YAML" > tmp.yaml && mv tmp.yaml "$PUBLISH_YAML"
+    sed -i'' -e "s/- main/- $VERSION/" "$PUBLISH_YAML"
+    echo "Branch replaced with version $VERSION in $PUBLISH_YAML."
 else
 	NAMESPACE="dotnet-sdk"
 fi

--- a/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/add_to_octokit_project.yml
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/add_to_octokit_project.yml
@@ -1,0 +1,20 @@
+name: Add PRs and issues to Octokit org project
+
+on:
+  issues:
+    types: [reopened, opened]
+  pull_request_target:
+    types: [reopened, opened]
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/add-to-project@v1.0.1
+        with:
+          project-url: https://github.com/orgs/octokit/projects/10
+          github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
+          labeled: "Status: Stale"
+          label-operator: NOT

--- a/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/build.yml
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/build.yml
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: "Build and test .NET SDK"
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x.x'
+
+      - name: Build the project
+        run: dotnet build src/GitHub.Octokit.GHES.SDK.csproj
+
+      - name: Format
+        run: dotnet format --verify-no-changes
+
+      - name: Test SDK
+        run: dotnet test -p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover -p:ExcludeByFile="**/GitHub/**/*.cs"
+
+      - name: Build and strong name sign
+        run: dotnet build src/GitHub.Octokit.GHES.SDK.csproj --no-incremental /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=../key.snk

--- a/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/build.yml
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/build.yml
@@ -5,10 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+      - main
 
 jobs:
   build:

--- a/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/immediate-response.yml
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/immediate-response.yml
@@ -1,0 +1,29 @@
+name: Issue/PR response
+permissions:
+  issues: write
+  pull-requests: write
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+jobs:
+  respond-to-issue:
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'githubactions[bot]' && github.actor != 'octokitbot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine issue or PR number
+        id: extract
+        run: echo "NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Respond to issue or PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ steps.extract.outputs.NUMBER }}
+          body: >
+            👋 Hi! Thank you for this contribution! Just to let you know, our GitHub SDK team does a round of issue and PR reviews twice a week, every Monday and Friday!
+            We have a [process in place](https://github.com/octokit/.github/blob/main/community/prioritization_response.md#overview) for prioritizing and responding to your input. 
+            Because you are a part of this community please feel free to comment, add to, or pick up any issues/PRs that are labeled with `Status: Up for grabs`.
+            You & others like you are the reason all of this works! So thank you & happy coding! 🚀

--- a/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/publish.yml
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish Release to NuGet
+
+on:
+  release:
+    types: [published]
+    
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.x.x
+
+    - name: Build and strong name
+      run: dotnet build --configuration Release --no-incremental -p:version=${GITHUB_REF#refs/*/v} -p:SignAssembly=true -p:AssemblyOriginatorKeyFile=../key.snk
+
+    - name: Pack SDK
+      run: dotnet pack -p:version=${GITHUB_REF#refs/*/v} -o ./publish
+
+    - name: Ship to NuGet
+      run: dotnet nuget push ./publish/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate


### PR DESCRIPTION
Note: these changes are intentionally static; the platform version numbers (as branches) are intended to be fixed until we decide otherwise or release a GA where this can be more "fuzzy"

The approach for building and releasing GHES instances of the .NET SDK are as follows:

1. Generation happens when GHES OpenAPI definitions change
2. Generator creates branched based PRs with the new changes
3. `build.yml` fires off on GHES versioned branches in the GHES SDK repo - currently 4x
4. For each branch the push>branches collection is updated to only the version the branch is targeted for: i.e. 3.10...
5. Once validated and merged into each GHES versioned branch manually make a release
6. Release is made for each version which triggers `publish.yml`
7. Nuget pack evaluates the name and version of the package from `GitHub.Octokit.GHES.SDK.csproj`
8. It get's packed and signed and published to nuget 