### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       - dependency-name: 'github.com/microsoft/kiota*'
   - package-ecosystem: 'github-actions'
     directories:
+      - '.github/workflows'
       - 'stage/dotnet-sdk'
       - 'stage/dotnet-sdk-enterprise-cloud'
       - 'stage/dotnet-sdk-enterprise-server'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: 'nuget'
+    directories:
+      - 'stage/dotnet-sdk'
+      - 'stage/dotnet-sdk-enterprise-cloud'
+      - 'stage/dotnet-sdk-enterprise-server'
+    schedule:
+      interval: 'daily'
+    ignore:
+      - dependency-name: 'Microsoft.Kiota.*'
+  - package-ecosystem: 'gomod'
+    directories:
+      - 'stage/go-sdk'
+      - 'stage/go-sdk-enterprise-cloud'
+      - 'stage/go-sdk-enterprise-server'
+    schedule:
+      interval: 'daily'
+    ignore:
+      - dependency-name: 'github.com/microsoft/kiota*'
+  - package-ecosystem: 'github-actions'
+    directories:
+      - 'stage/dotnet-sdk'
+      - 'stage/dotnet-sdk-enterprise-cloud'
+      - 'stage/dotnet-sdk-enterprise-server'
+      - 'stage/go-sdk'
+      - 'stage/go-sdk-enterprise-cloud'
+      - 'stage/go-sdk-enterprise-server'
+    schedule:
+      interval: 'daily'

--- a/stage/go/go-sdk-enterprise-cloud/.github/dependabot.yml
+++ b/stage/go/go-sdk-enterprise-cloud/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/stage/go/go-sdk-enterprise-server/.github/dependabot.yml
+++ b/stage/go/go-sdk-enterprise-server/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/stage/go/go-sdk/.github/dependabot.yml
+++ b/stage/go/go-sdk/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This PR centralizes Dependabot configuration in the source-generator repository. It ignores Kiota dependencies as those are installed using the `kiota` CLI and should not be updated out-of-band. It updates NuGet, Go, and GitHub Actions dependencies across all of source-generator and the downstream SDKs. 