### PR TITLE
fix: GHES OpenAPI descriptions have the default host for the API set as a formatter not a URL

### DIFF
--- a/stage/dotnet/dotnet-sdk-enterprise-server/README.md
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/README.md
@@ -60,7 +60,7 @@ using GitHub.Octokit.Client.Authentication;
 
 var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "";
 var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider), "https://hosted.instance");
-var gitHubClient = new GitHubClient(request);
+var gitHubClient = new GitHubClient(adapter);
 
 var pullRequests = await gitHubClient.Repos["octokit"]["octokit.net"].Pulls.GetAsync();
 

--- a/stage/dotnet/dotnet-sdk-enterprise-server/README.md
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/README.md
@@ -46,10 +46,9 @@ To install the package, you can use either of the following options:
 Given that the GHES platform is a self hosted instance when using this SDK you'll need to initialize it with your host and protocol:
 
 ```
-	var tokenProvider = new TokenProvider(Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "");
-	var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider));
-	adapter.BaseAddress = new Uri("https://hosted.instance");
-	var gitHubClient = new GitHubClient(adapter);
+        var tokenProvider = new TokenProvider(Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "");
+        var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider), "https://api.github.com");
+        var gitHubClient = new GitHubClient(adapter);
 ```
 
 ### Make your first request

--- a/stage/dotnet/dotnet-sdk-enterprise-server/README.md
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/README.md
@@ -40,6 +40,18 @@ To install the package, you can use either of the following options:
 - Type `Install-Package GitHub.Octokit.SDK` into the Package Manager Console, or
 - Type `dotnet add ./path/to/myproject.csproj package GitHub.Octokit.SDK` in a terminal (replace `./path/to/myproject.csproj` by the path to the _*.csproj_ file you want to add the dependency)
 
+
+### Initializing
+
+Given that the GHES platform is a self hosted instance when using this SDK you'll need to initialize it with your host and protocol:
+
+```
+	var tokenProvider = new TokenProvider(Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "");
+	var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider));
+	adapter.BaseAddress = new Uri("https://hosted.instance");
+	var gitHubClient = new GitHubClient(adapter);
+```
+
 ### Make your first request
 
 ```csharp

--- a/stage/dotnet/dotnet-sdk-enterprise-server/README.md
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/README.md
@@ -45,9 +45,9 @@ To install the package, you can use either of the following options:
 
 Given that the GHES platform is a self hosted instance when using this SDK you'll need to initialize it with your host and protocol:
 
-```
+```csharp
         var tokenProvider = new TokenProvider(Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "");
-        var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider), "https://api.github.com");
+        var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider), "https://hosted.instance");
         var gitHubClient = new GitHubClient(adapter);
 ```
 
@@ -59,7 +59,7 @@ using GitHub.Octokit.Client;
 using GitHub.Octokit.Client.Authentication;
 
 var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "";
-var request = RequestAdapter.Create(new TokenAuthProvider(new TokenProvider(token)));
+var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider), "https://hosted.instance");
 var gitHubClient = new GitHubClient(request);
 
 var pullRequests = await gitHubClient.Repos["octokit"]["octokit.net"].Pulls.GetAsync();

--- a/stage/dotnet/dotnet-sdk-enterprise-server/cli/Authentication/PersonalAccessToken.cs
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/cli/Authentication/PersonalAccessToken.cs
@@ -19,6 +19,7 @@ public class PersonalAccessToken
         // Personal Access Token authentication
         var tokenProvider = new TokenProvider(Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "");
         var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider));
+        adapter.BaseAddress = new Uri("https://api.github.com");
         var gitHubClient = new GitHubClient(adapter);
 
         try

--- a/stage/dotnet/dotnet-sdk-enterprise-server/cli/Authentication/PersonalAccessToken.cs
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/cli/Authentication/PersonalAccessToken.cs
@@ -18,8 +18,7 @@ public class PersonalAccessToken
     {
         // Personal Access Token authentication
         var tokenProvider = new TokenProvider(Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "");
-        var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider));
-        adapter.BaseAddress = new Uri("https://api.github.com");
+        var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider), "https://api.github.com");
         var gitHubClient = new GitHubClient(adapter);
 
         try

--- a/stage/dotnet/dotnet-sdk-enterprise-server/src/Client/RequestAdapter.cs
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/src/Client/RequestAdapter.cs
@@ -25,4 +25,25 @@ public static class RequestAdapter
 
         return gitHubRequestAdapter;
     }
+    public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider, string baseUrl, HttpClient? clientFactory = null)
+    {
+        if (string.IsNullOrEmpty(baseUrl))
+        {
+            throw new ArgumentException("Base URL cannot be null or empty.", nameof(baseUrl));
+        }
+
+        clientFactory ??= ClientFactory.Create();
+
+        var gitHubRequestAdapter = new HttpClientRequestAdapter(
+            authenticationProvider,
+            null, // Node Parser
+            null, // Serializer
+            clientFactory,
+            null)
+        {
+            BaseUrl = baseUrl
+        };
+
+        return gitHubRequestAdapter;
+    }
 }

--- a/stage/dotnet/dotnet-sdk/cli/Authentication/PersonalAccessToken.cs
+++ b/stage/dotnet/dotnet-sdk/cli/Authentication/PersonalAccessToken.cs
@@ -18,7 +18,7 @@ public class PersonalAccessToken
     {
         // Personal Access Token authentication
         var tokenProvider = new TokenProvider(Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? "");
-        var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider));
+        var adapter = RequestAdapter.Create(new TokenAuthProvider(tokenProvider), "https://api.github.com");
         var gitHubClient = new GitHubClient(adapter);
 
         try

--- a/stage/dotnet/dotnet-sdk/src/Client/RequestAdapter.cs
+++ b/stage/dotnet/dotnet-sdk/src/Client/RequestAdapter.cs
@@ -25,4 +25,20 @@ public static class RequestAdapter
 
         return gitHubRequestAdapter;
     }
+    public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider, string baseUrl, HttpClient? clientFactory = null)
+    {
+        clientFactory ??= ClientFactory.Create();
+
+        var gitHubRequestAdapter =
+          new HttpClientRequestAdapter(
+            authenticationProvider,
+            null, // Node Parser
+            null, // Serializer
+            clientFactory,
+            null) {
+                BaseUrl = baseUrl
+            };
+            
+        return gitHubRequestAdapter;
+    }
 }

--- a/stage/dotnet/dotnet-sdk/src/Client/RequestAdapter.cs
+++ b/stage/dotnet/dotnet-sdk/src/Client/RequestAdapter.cs
@@ -25,20 +25,4 @@ public static class RequestAdapter
 
         return gitHubRequestAdapter;
     }
-    public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider, string baseUrl, HttpClient? clientFactory = null)
-    {
-        clientFactory ??= ClientFactory.Create();
-
-        var gitHubRequestAdapter =
-          new HttpClientRequestAdapter(
-            authenticationProvider,
-            null, // Node Parser
-            null, // Serializer
-            clientFactory,
-            null) {
-                BaseUrl = baseUrl
-            };
-            
-        return gitHubRequestAdapter;
-    }
 }

--- a/stage/go/go-sdk-enterprise-server/README.md
+++ b/stage/go/go-sdk-enterprise-server/README.md
@@ -42,6 +42,21 @@ See example client instantiations and requests in [example_test.go](pkg/example_
 	- Test coverage may be viewed in VS Code by running the command `Go: Toggle Test Coverage In Current Package`
 	- Alternately, you may run `go tool cover -html auth.cov -o auth.html` and open the generated `auth.html` file in a browser to view test coverage
 
+### Initializing
+
+Given that the GHES platform is a self hosted instance when using this SDK you'll need to initialize it with your host and protocol:
+
+```
+client, err := pkg.NewApiClient(
+		pkg.WithUserAgent("octokit/go-sdk.example-functions"),
+		pkg.WithRequestTimeout(5*time.Second),
+		pkg.WithBaseUrl("https://hosted.instance"),
+		pkg.WithTokenAuthentication(token),
+	)
+```
+
+or by using the `SetBaseUrl` function from the `kiotaHttp.NewNetHttpRequestAdapter` 
+
 ### Authentication
 
 This SDK supports [Personal Access Tokens (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#personal-access-tokens-classic), [fine-grained Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens), and [GitHub Apps](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app) authentication.

--- a/stage/go/go-sdk-enterprise-server/README.md
+++ b/stage/go/go-sdk-enterprise-server/README.md
@@ -46,16 +46,28 @@ See example client instantiations and requests in [example_test.go](pkg/example_
 
 Given that the GHES platform is a self hosted instance when using this SDK you'll need to initialize it with your host and protocol:
 
-```
+```go
 client, err := pkg.NewApiClient(
-		pkg.WithUserAgent("octokit/go-sdk.example-functions"),
-		pkg.WithRequestTimeout(5*time.Second),
-		pkg.WithBaseUrl("https://hosted.instance"),
-		pkg.WithTokenAuthentication(token),
-	)
+	pkg.WithUserAgent("octokit/go-sdk.example-functions"),
+	pkg.WithRequestTimeout(5*time.Second),
+	pkg.WithBaseUrl("https://hosted.instance"),
+	pkg.WithTokenAuthentication(token),
+)
 ```
 
 or by using the `SetBaseUrl` function from the `kiotaHttp.NewNetHttpRequestAdapter` 
+
+```go
+tokenProvider := auth.NewTokenProvider(
+	auth.WithUserAgent("octokit/go-sdk.example-functions"),
+)
+adapter, err := kiotaHttp.NewNetHttpRequestAdapter(tokenProvider)
+if err != nil {
+	log.Fatalf("Error creating request adapter: %v", err)
+}
+adapter.SetBaseUrl("https://hosted.instance")
+client := github.NewApiClient(adapter)
+```
 
 ### Authentication
 

--- a/stage/go/go-sdk-enterprise-server/pkg/authentication/token_provider_test.go
+++ b/stage/go/go-sdk-enterprise-server/pkg/authentication/token_provider_test.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
-	http "github.com/microsoft/kiota-http-go"
+	"github.com/octokit/go-sdk-enterprise-server/pkg"
 	"github.com/octokit/go-sdk-enterprise-server/pkg/authentication"
-	"github.com/octokit/go-sdk-enterprise-server/pkg/github"
 	"github.com/octokit/go-sdk-enterprise-server/pkg/github/user"
 	"github.com/octokit/go-sdk-enterprise-server/pkg/headers"
 )
@@ -155,18 +155,20 @@ func TestHappyPathIntegration(t *testing.T) {
 		t.Skip("in order to run integration tests, ensure a valid GITHUB_TOKEN exists in the environment")
 	}
 
-	provider := authentication.NewTokenProvider(
-		authentication.WithTokenAuthentication(token),
+	// TODO: Rework this test to fit the platform needs of GHES
+	client, err := pkg.NewApiClient(
+		pkg.WithUserAgent("octokit/go-sdk.example-functions"),
+		pkg.WithRequestTimeout(5*time.Second),
+		pkg.WithBaseUrl("https://api.github.com"),
+		pkg.WithTokenAuthentication(token),
 	)
 
-	adapter, err := http.NewNetHttpRequestAdapter(provider)
 	if err != nil {
-		log.Fatalf("Error creating request adapter: %v", err)
+		log.Fatalf("error creating client: %v", err)
 	}
+
 	headers := abstractions.NewRequestHeaders()
 	_ = headers.TryAdd("Accept", "application/vnd.github.v3+json")
-
-	client := github.NewApiClient(adapter)
 
 	// Create a new instance of abstractions.RequestConfiguration
 	requestConfig := &abstractions.RequestConfiguration[user.EmailsRequestBuilderGetQueryParameters]{

--- a/stage/go/go-sdk-enterprise-server/pkg/example_test.go
+++ b/stage/go/go-sdk-enterprise-server/pkg/example_test.go
@@ -88,6 +88,14 @@ func ExampleApiClient_Octocat_withoutConvenienceConstructor() {
 		log.Fatalf("Error creating request adapter: %v", err)
 	}
 
+	// TODO: Rework this test to fit the platform needs of GHES
+	// possibly add APIs the GHES SDK to provide base URL values to the formatter
+	baseUrl := adapter.GetBaseUrl()
+
+	if baseUrl == "" {
+		adapter.SetBaseUrl("https://api.github.com")
+	}
+
 	client := github.NewApiClient(adapter)
 
 	s := "Salutations"

--- a/stage/go/go-sdk-enterprise-server/pkg/example_test.go
+++ b/stage/go/go-sdk-enterprise-server/pkg/example_test.go
@@ -92,6 +92,8 @@ func ExampleApiClient_Octocat_withoutConvenienceConstructor() {
 	// possibly add APIs the GHES SDK to provide base URL values to the formatter
 	baseUrl := adapter.GetBaseUrl()
 
+    // Note: This SDK should be used against a GitHub Enterprise instance, and the below URL is the public GitHub one. It's here only so that tests pass when running `go test ./...`, as the OpenAPI schema for GHES understandably does not include a baseURL.
+    // When setting up this package for your own usage, call `adapter.SetBaseUrl` or `pkg.WithBaseUrl` with your own GHES base URL.
 	if baseUrl == "" {
 		adapter.SetBaseUrl("https://api.github.com")
 	}

--- a/stage/go/go-sdk-enterprise-server/pkg/example_test.go
+++ b/stage/go/go-sdk-enterprise-server/pkg/example_test.go
@@ -89,7 +89,6 @@ func ExampleApiClient_Octocat_withoutConvenienceConstructor() {
 	}
 
 	// TODO: Rework this test to fit the platform needs of GHES
-	// possibly add APIs the GHES SDK to provide base URL values to the formatter
 	baseUrl := adapter.GetBaseUrl()
 
     // Note: This SDK should be used against a GitHub Enterprise instance, and the below URL is the public GitHub one. It's here only so that tests pass when running `go test ./...`, as the OpenAPI schema for GHES understandably does not include a baseURL.


### PR DESCRIPTION
Initial rework of GHES tests to so that a proper default host is used and not the formatter provided by the OpenAPI definitions.

![image](https://github.com/user-attachments/assets/259d95e3-503c-4af6-8eb0-43ace2dc8e5b)

dotcom:
```
servers:
- url: https://api.github.com
```

GHES
```
servers:
- url: "{protocol}://{hostname}/api/v3"
```

GHEC
```
servers:
- url: https://api.github.com
```

We already have an API that allows the setting of baseurl
``` Go
	adapter, err := kiotaHttp.NewNetHttpRequestAdapter(tokenProvider)
	if err != nil {
		log.Fatalf("Error creating request adapter: %v", err)
	}

	adapter.SetBaseUrl("https://api.github.com")
```