### PR TITLE
Fix stage directories for dependabot runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,18 @@ version: 2
 updates:
   - package-ecosystem: 'nuget'
     directories:
-      - 'stage/dotnet-sdk'
-      - 'stage/dotnet-sdk-enterprise-cloud'
-      - 'stage/dotnet-sdk-enterprise-server'
+      - 'stage/dotnet/dotnet-sdk'
+      - 'stage/dotnet/dotnet-sdk-enterprise-cloud'
+      - 'stage/dotnet/dotnet-sdk-enterprise-server'
     schedule:
       interval: 'daily'
     ignore:
       - dependency-name: 'Microsoft.Kiota.*'
   - package-ecosystem: 'gomod'
     directories:
-      - 'stage/go-sdk'
-      - 'stage/go-sdk-enterprise-cloud'
-      - 'stage/go-sdk-enterprise-server'
+      - 'stage/go/go-sdk'
+      - 'stage/go/go-sdk-enterprise-cloud'
+      - 'stage/go/go-sdk-enterprise-server'
     schedule:
       interval: 'daily'
     ignore:
@@ -21,11 +21,11 @@ updates:
   - package-ecosystem: 'github-actions'
     directories:
       - '.github/workflows'
-      - 'stage/dotnet-sdk'
-      - 'stage/dotnet-sdk-enterprise-cloud'
-      - 'stage/dotnet-sdk-enterprise-server'
-      - 'stage/go-sdk'
-      - 'stage/go-sdk-enterprise-cloud'
-      - 'stage/go-sdk-enterprise-server'
+      - 'stage/dotnet/dotnet-sdk'
+      - 'stage/dotnet/dotnet-sdk-enterprise-cloud'
+      - 'stage/dotnet/dotnet-sdk-enterprise-server'
+      - 'stage/go/go-sdk'
+      - 'stage/go/go-sdk-enterprise-cloud'
+      - 'stage/go/go-sdk-enterprise-server'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
Dependabot logs can be viewed by going to repo Insights --> Dependency graph --> Dependabot. From there, you can click your ecosystem of choice and view recent logs or manually trigger jobs. Discovering this fact helped me view logs like [this one](https://github.com/octokit/source-generator/actions/runs/10188323278/job/28184258286), which made me realize I mistyped the stage directories when I filled this out in the first place :facepalm: :facepalm: :facepalm: 