### PR TITLE
Group NuGet Dependabot runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,11 +29,11 @@ updates:
   - package-ecosystem: 'github-actions'
     directories:
       - '.github/workflows'
-      - 'stage/dotnet/dotnet-sdk'
-      - 'stage/dotnet/dotnet-sdk-enterprise-cloud'
-      - 'stage/dotnet/dotnet-sdk-enterprise-server'
-      - 'stage/go/go-sdk'
-      - 'stage/go/go-sdk-enterprise-cloud'
-      - 'stage/go/go-sdk-enterprise-server'
+      - 'stage/dotnet/dotnet-sdk/.github/workflows'
+      - 'stage/dotnet/dotnet-sdk-enterprise-cloud/.github/workflows'
+      - 'stage/dotnet/dotnet-sdk-enterprise-server.github/workflows'
+      - 'stage/go/go-sdk/.github/workflows'
+      - 'stage/go/go-sdk-enterprise-cloud/.github/workflows'
+      - 'stage/go/go-sdk-enterprise-server/.github/workflows'
     schedule:
       interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       interval: 'daily'
     ignore:
       - dependency-name: 'Microsoft.Kiota.*'
+    groups:
+      test:
+        patterns:
+          - 'xunit*'
+          - 'coverlet*'
+      microsoft:
+        patterns:
+          - 'Microsoft.*'
   - package-ecosystem: 'gomod'
     directories:
       - 'stage/go/go-sdk'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,18 @@ version: 2
 updates:
   - package-ecosystem: 'nuget'
     directories:
-      - 'stage/dotnet-sdk'
-      - 'stage/dotnet-sdk-enterprise-cloud'
-      - 'stage/dotnet-sdk-enterprise-server'
+      - 'stage/dotnet/dotnet-sdk'
+      - 'stage/dotnet/dotnet-sdk-enterprise-cloud'
+      - 'stage/dotnet/dotnet-sdk-enterprise-server'
     schedule:
       interval: 'daily'
     ignore:
       - dependency-name: 'Microsoft.Kiota.*'
   - package-ecosystem: 'gomod'
     directories:
-      - 'stage/go-sdk'
-      - 'stage/go-sdk-enterprise-cloud'
-      - 'stage/go-sdk-enterprise-server'
+      - 'stage/go/go-sdk'
+      - 'stage/go/go-sdk-enterprise-cloud'
+      - 'stage/go/go-sdk-enterprise-server'
     schedule:
       interval: 'daily'
     ignore:
@@ -21,11 +21,11 @@ updates:
   - package-ecosystem: 'github-actions'
     directories:
       - '.github/workflows'
-      - 'stage/dotnet-sdk'
-      - 'stage/dotnet-sdk-enterprise-cloud'
-      - 'stage/dotnet-sdk-enterprise-server'
-      - 'stage/go-sdk'
-      - 'stage/go-sdk-enterprise-cloud'
-      - 'stage/go-sdk-enterprise-server'
+      - 'stage/dotnet/dotnet-sdk'
+      - 'stage/dotnet/dotnet-sdk-enterprise-cloud'
+      - 'stage/dotnet/dotnet-sdk-enterprise-server'
+      - 'stage/go/go-sdk'
+      - 'stage/go/go-sdk-enterprise-cloud'
+      - 'stage/go/go-sdk-enterprise-server'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
Group NuGet Dependabot runs to avoid "too many PRs" failures like this: 

![image](https://github.com/user-attachments/assets/ca025c62-d961-4e74-bb6b-325972da7fa5)

Also link to exact directories where workflows exist in PRs. Dependabot updates for Actions won't run until #76 is merged to add that directory. 