### PR TITLE
Don't post-process .NET GitHub.Models.Team issues anymore

### DIFF
--- a/post-processors/csharp/main.go
+++ b/post-processors/csharp/main.go
@@ -50,7 +50,6 @@ func run() error {
 
 		fileContents = fixThumbsUpThumbsDownProperties(fileContents)
 		fileContents = fixPagesPaths(fileContents)
-		fileContents = fixKiotaTeamErrors(fileContents, path)
 		fileContents = fixKiotaUntypedNodeErrors(fileContents, path)
 
 		err = os.WriteFile(path, []byte(fileContents), 0600)
@@ -154,35 +153,6 @@ func fixPagesPaths(inputFile string) string {
 	// find: Path = PagesPostRequestBody_source_path.;
 	// replace: Path = PagesPostRequestBody_source_path.Root;
 	inputFile = strings.ReplaceAll(inputFile, "Path = PagesPostRequestBody_source_path.;", "Path = PagesPostRequestBody_source_path.Docs;")
-	return inputFile
-}
-
-func fixKiotaTeamErrors(inputFile string, filePath string) string {
-	if !strings.Contains(filePath, "Orgs/Item/Invitations/Item/Teams/TeamsRequestBuilder.cs") &&
-		!strings.Contains(filePath, "Orgs/Item/OrganizationRoles/Item/Teams/TeamsRequestBuilder.cs") &&
-		!strings.Contains(filePath, "Orgs/Item/Teams/Item/Teams/TeamsRequestBuilder.cs") &&
-		!strings.Contains(filePath, "Orgs/Item/Teams/TeamsRequestBuilder.cs") {
-		return inputFile
-	}
-
-	toReplace := "Task<List<Team>"
-	replaceWith := "Task<List<GitHub.Models.Team>"
-	if strings.Contains(inputFile, toReplace) {
-		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
-	}
-
-	toReplace = "SendCollectionAsync<Team>"
-	replaceWith = "SendCollectionAsync<GitHub.Models.Team>"
-	if strings.Contains(inputFile, toReplace) {
-		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
-	}
-
-	toReplace = "Team.CreateFromDiscriminatorValue"
-	replaceWith = "GitHub.Models.Team.CreateFromDiscriminatorValue"
-	if strings.Contains(inputFile, toReplace) {
-		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
-	}
-
 	return inputFile
 }
 


### PR DESCRIPTION
Starting [Friday](https://github.com/octokit/source-generator/actions/runs/10311495117/job/28545187915), our .NET builds began failing with the following errors: 

```
Error: /home/runner/work/source-generator/source-generator/stage/dotnet/dotnet-sdk/src/GitHub/Orgs/Item/Teams/TeamsRequestBuilder.cs(68,110): error CS0234: The type or namespace name 'GitHub' does not exist in the namespace 'GitHub.Models' (are you missing an assembly reference?) [/home/runner/work/source-generator/source-generator/stage/dotnet/dotnet-sdk/src/GitHub.Octokit.SDK.csproj]
Error: /home/runner/work/source-generator/source-generator/stage/dotnet/dotnet-sdk/src/GitHub/Orgs/Item/Teams/Item/Teams/TeamsRequestBuilder.cs(50,110): error CS0234: The type or namespace name 'GitHub' does not exist in the namespace 'GitHub.Models' (are you missing an assembly reference?) [/home/runner/work/source-generator/source-generator/stage/dotnet/dotnet-sdk/src/GitHub.Octokit.SDK.csproj]
Error: /home/runner/work/source-generator/source-generator/stage/dotnet/dotnet-sdk/src/GitHub/Orgs/Item/Invitations/Item/Teams/TeamsRequestBuilder.cs(55,110): error CS0234: The type or namespace name 'GitHub' does not exist in the namespace 'GitHub.Models' (are you missing an assembly reference?) [/home/runner/work/source-generator/source-generator/stage/dotnet/dotnet-sdk/src/GitHub.Octokit.SDK.csproj]
```

We had a post-processing step in place to fix errors with Kiota generation around the Teams model. Since nothing changed in our main Kiota version or our dependencies, I believe the errors are due to a fix in the spec, possibly https://github.com/github/rest-api-description/pull/3827. 

Removing the post-processing spec causes the code to generate correctly again. 
