### PR TITLE
Add request adapter newlines

### DIFF
--- a/stage/dotnet/dotnet-sdk-enterprise-cloud/src/Client/RequestAdapter.cs
+++ b/stage/dotnet/dotnet-sdk-enterprise-cloud/src/Client/RequestAdapter.cs
@@ -31,3 +31,4 @@ public class RequestAdapter
         return gitHubRequestAdapter;
     }
 }
+

--- a/stage/dotnet/dotnet-sdk-enterprise-server/src/Client/RequestAdapter.cs
+++ b/stage/dotnet/dotnet-sdk-enterprise-server/src/Client/RequestAdapter.cs
@@ -52,3 +52,4 @@ public class RequestAdapter
         return gitHubRequestAdapter;
     }
 }
+

--- a/stage/dotnet/dotnet-sdk/src/Client/RequestAdapter.cs
+++ b/stage/dotnet/dotnet-sdk/src/Client/RequestAdapter.cs
@@ -31,3 +31,4 @@ public class RequestAdapter
         return gitHubRequestAdapter;
     }
 }
+


### PR DESCRIPTION
Builds are failing still on formatting errors like [this one](https://github.com/octokit/dotnet-sdk/actions/runs/10426487008/job/28879509943?pr=111): 

> /home/runner/work/dotnet-sdk/dotnet-sdk/src/Client/RequestAdapter.cs(33,2): error FINALNEWLINE: Fix final newline. Insert '\n'. [/home/runner/work/dotnet-sdk/dotnet-sdk/src/GitHub.Octokit.SDK.csproj]

I wonder if I have an editor configuration issue, or else there's something wonky going on with the copy step that's removing the whitespace. Locally, I had a newline added at the end of the file, and running `dotnet format --verify-no-changes` succeeded for me. 

However, the PR updates still showed the whitespace removed: 
![image](https://github.com/user-attachments/assets/3eea2699-4545-4fc0-9b8a-c4e0f5a8f89d)

This PR manually adds it back. 