### PR TITLE
Fix zipball/tarball downloading issue in C# and Go

### DIFF
--- a/post-processors/go/main.go
+++ b/post-processors/go/main.go
@@ -42,6 +42,7 @@ func run() error {
 		}
 
 		fileContents = fixKiotaFileNameTypeNameError(fileContents, file.Name())
+		fileContents = fixMissingContentTypeOnRedirect(fileContents, file.Name())
 
 		err = os.WriteFile(path, []byte(fileContents), 0600)
 		if err != nil {
@@ -170,5 +171,72 @@ func fixKiotaFileNameTypeNameError(inputFile string, fileName string) string {
 	if strings.Contains(inputFile, toReplace) {
 		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
 	}
+	return inputFile
+}
+
+func fixMissingContentTypeOnRedirect(inputFile string, fileName string) string {
+	if !strings.Contains(fileName, "item_item_zipball_with_ref_item_request_builder.go") &&
+		!strings.Contains(fileName, "item_item_tarball_with_ref_item_request_builder.go") {
+		return inputFile
+	}
+
+	toReplace := `func (m *ItemItemTarballWithRefItemRequestBuilder) Get(ctx context.Context, requestConfiguration *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestConfiguration[i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.DefaultQueryParameters])(error) {
+    requestInfo, err := m.ToGetRequestInformation(ctx, requestConfiguration);
+    if err != nil {
+        return err
+    }
+    err = m.BaseRequestBuilder.RequestAdapter.SendNoContent(ctx, requestInfo, nil)
+    if err != nil {
+        return err
+    }
+    return nil`
+
+	replaceWith := `func (m *ItemItemTarballWithRefItemRequestBuilder) Get(ctx context.Context, requestConfiguration *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestConfiguration[i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.DefaultQueryParameters])([]byte, error) {
+    requestInfo, err := m.ToGetRequestInformation(ctx, requestConfiguration);
+    if err != nil {
+        return nil, err
+    }
+    res, err := m.BaseRequestBuilder.RequestAdapter.SendPrimitive(ctx, requestInfo, "[]byte", nil)
+    if err != nil {
+        return nil, err
+    }
+    if res == nil {
+        return nil, nil
+    }
+    return res.([]byte), nil`
+
+	if strings.Contains(inputFile, toReplace) {
+		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
+	}
+
+	toReplace = `func (m *ItemItemZipballWithRefItemRequestBuilder) Get(ctx context.Context, requestConfiguration *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestConfiguration[i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.DefaultQueryParameters])(error) {
+    requestInfo, err := m.ToGetRequestInformation(ctx, requestConfiguration);
+    if err != nil {
+        return err
+    }
+    err = m.BaseRequestBuilder.RequestAdapter.SendNoContent(ctx, requestInfo, nil)
+    if err != nil {
+        return err
+    }
+    return nil`
+
+	replaceWith = `func (m *ItemItemZipballWithRefItemRequestBuilder) Get(ctx context.Context, requestConfiguration *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestConfiguration[i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.DefaultQueryParameters])([]byte, error) {
+    requestInfo, err := m.ToGetRequestInformation(ctx, requestConfiguration);
+    if err != nil {
+        return nil, err
+    }
+    res, err := m.BaseRequestBuilder.RequestAdapter.SendPrimitive(ctx, requestInfo, "[]byte", nil)
+    if err != nil {
+        return nil, err
+    }
+    if res == nil {
+        return nil, nil
+    }
+    return res.([]byte), nil`
+
+	if strings.Contains(inputFile, toReplace) {
+		inputFile = strings.ReplaceAll(inputFile, toReplace, replaceWith)
+	}
+
 	return inputFile
 }


### PR DESCRIPTION
Fixes https://github.com/octokit/dotnet-sdk/issues/71. 

We have an issue with our specification/a Kiota design decision: Kiota expects the schema to represent the final result of the redirect. Our schema only gives the redirect itself: a Location header with a URL. The best middle ground is probably a mixture of both, in which the schema of the results of the download are described in the 302 response, but Kiota does not parse that right now, and this gets us immediately unblocked. 

I've validated locally that both tarballs and zips can be downloaded in C# and Go using the output of the generated code.