### PR TITLE
Deprecate GHES 3.10 and introduce GHES 3.14

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -70,7 +70,7 @@ jobs:
   server-builds:
     strategy:
       matrix:
-        version: ["3.10", "3.11", "3.12", "3.13"] # versions must be quoted or 3.10 becomes 3.1
+        version: ["3.11", "3.12", "3.13", "3.14"] # versions must be quoted or 3.10 becomes 3.1
       fail-fast: false
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -67,7 +67,7 @@ jobs:
   server-builds:
     strategy:
       matrix:
-        version: ["3.10", "3.11", "3.12", "3.13"] # versions must be quoted or 3.10 becomes 3.1
+        version: ["3.11", "3.12", "3.13", "3.14"] # versions must be quoted or 3.10 becomes 3.1
       fail-fast: false
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
According to [this docs page](https://docs.github.com/en/enterprise-server@3.12/admin/all-releases), as of August 8th, GHES 3.14 has been released. As of August 29th, GHES 3.10 has been deprecated. Let's make those changes too!

Sidenote: This catches all instances of 3.10 in the project. Are there other tasks I'm not thinking of? Maybe we need to mark 3.10 as deprecated in Nuget or something? 