### PR TITLE
Updates Microsoft.OpenAPI.Kiota generator tool from v1.18.0 to v1.19.0

### DIFF
--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -6,4 +6,4 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
 # Install Kiota
 # This version can only increase, never decrease. If you want to use a lower version, you need to uninstall the tool first.
 # dotnet tool uninstall Microsoft.OpenApi.Kiota --global
-dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.18.0
+dotnet tool install --global Microsoft.OpenApi.Kiota --version 1.19.0


### PR DESCRIPTION
This will address 3 of our issues with the generated code around discriminators and types