### PR TITLE
Set BaseURL for ghinstallation for GitHub Apps

### DIFF
--- a/stage/go/go-sdk-enterprise-cloud/pkg/client.go
+++ b/stage/go/go-sdk-enterprise-cloud/pkg/client.go
@@ -51,6 +51,10 @@ func NewApiClient(optionFuncs ...ClientOptionFunc) (*Client, error) {
 			return nil, fmt.Errorf("failed to create transport from GitHub App: %v", err)
 		}
 
+		if options.BaseURL != "" {
+			appTransport.BaseURL = options.BaseURL
+		}
+
 		netHttpClient.Transport = appTransport
 	}
 

--- a/stage/go/go-sdk-enterprise-cloud/pkg/client_test.go
+++ b/stage/go/go-sdk-enterprise-cloud/pkg/client_test.go
@@ -1,9 +1,15 @@
 package pkg
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
+	abs "github.com/microsoft/kiota-abstractions-go"
+	"github.com/octokit/go-sdk-enterprise-cloud/pkg/github/installation"
 	"github.com/octokit/go-sdk-enterprise-cloud/pkg/headers"
 )
 
@@ -88,6 +94,49 @@ func TestNewApiClientAppAuthHappyPath(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatalf("client is nil")
+	}
+}
+
+func TestNewApiClientAppAuthBaseUrl(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", pemFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write(key); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedCall := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/app/installations") {
+			expectedCall = true
+		}
+	}))
+
+	client, err := NewApiClient(
+		WithGitHubAppAuthentication(tmpfile.Name(), clientID, installationID),
+		WithBaseUrl(server.URL),
+	)
+	if err != nil {
+		t.Fatalf("error creating client: %v", err)
+	}
+	if client == nil {
+		t.Fatalf("client is nil")
+	}
+	queryParams := &installation.RepositoriesRequestBuilderGetQueryParameters{}
+	requestConfig := &abs.RequestConfiguration[installation.RepositoriesRequestBuilderGetQueryParameters]{
+		QueryParameters: queryParams,
+	}
+
+	// trigger a refresh of the installation token to the expected url
+	_, _ = client.Installation().Repositories().Get(context.Background(), requestConfig)
+	if !expectedCall {
+		t.Errorf("installation token endpoint not called")
 	}
 }
 

--- a/stage/go/go-sdk-enterprise-server/pkg/client.go
+++ b/stage/go/go-sdk-enterprise-server/pkg/client.go
@@ -51,6 +51,10 @@ func NewApiClient(optionFuncs ...ClientOptionFunc) (*Client, error) {
 			return nil, fmt.Errorf("failed to create transport from GitHub App: %v", err)
 		}
 
+		if options.BaseURL != "" {
+			appTransport.BaseURL = options.BaseURL
+		}
+
 		netHttpClient.Transport = appTransport
 	}
 

--- a/stage/go/go-sdk-enterprise-server/pkg/client_test.go
+++ b/stage/go/go-sdk-enterprise-server/pkg/client_test.go
@@ -1,9 +1,15 @@
 package pkg
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
+	abs "github.com/microsoft/kiota-abstractions-go"
+	"github.com/octokit/go-sdk-enterprise-server/pkg/github/installation"
 	"github.com/octokit/go-sdk-enterprise-server/pkg/headers"
 )
 
@@ -88,6 +94,49 @@ func TestNewApiClientAppAuthHappyPath(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatalf("client is nil")
+	}
+}
+
+func TestNewApiClientAppAuthBaseUrl(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", pemFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write(key); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedCall := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/app/installations") {
+			expectedCall = true
+		}
+	}))
+
+	client, err := NewApiClient(
+		WithGitHubAppAuthentication(tmpfile.Name(), clientID, installationID),
+		WithBaseUrl(server.URL),
+	)
+	if err != nil {
+		t.Fatalf("error creating client: %v", err)
+	}
+	if client == nil {
+		t.Fatalf("client is nil")
+	}
+	queryParams := &installation.RepositoriesRequestBuilderGetQueryParameters{}
+	requestConfig := &abs.RequestConfiguration[installation.RepositoriesRequestBuilderGetQueryParameters]{
+		QueryParameters: queryParams,
+	}
+
+	// trigger a refresh of the installation token to the expected url
+	_, _ = client.Installation().Repositories().Get(context.Background(), requestConfig)
+	if !expectedCall {
+		t.Errorf("installation token endpoint not called")
 	}
 }
 

--- a/stage/go/go-sdk/pkg/client.go
+++ b/stage/go/go-sdk/pkg/client.go
@@ -51,6 +51,10 @@ func NewApiClient(optionFuncs ...ClientOptionFunc) (*Client, error) {
 			return nil, fmt.Errorf("failed to create transport from GitHub App: %v", err)
 		}
 
+		if options.BaseURL != "" {
+			appTransport.BaseURL = options.BaseURL
+		}
+
 		netHttpClient.Transport = appTransport
 	}
 


### PR DESCRIPTION
In testing https://github.com/octokit/go-sdk I found that when using GitHub App authentication, the ghinstallation dependency has a hardcoded `https://api.github.com` for token refreshes. In local development (and I think for Enterprise Server in general) this means that the `WithBaseUrl` option does not take effect when generating an Installation token.

This PR sets the ghinstallation `appTransport.BaseURL` when `WithBaseUrl` is used.

I added a new test using `httptest.NewServer` as I didn't see a good way to reflect on the state of the ghinstallation transport.

In running `./scripts/generate-go.sh ...` I noticed it updated go.mod with some minor version bumps, but I have not included the diffs for go.mod and go.sum -- let me know if those should be included, but there are no new dependencies here.

I think this should be backported for supported Enterprise Server versions, but I'm not sure what the process is there.